### PR TITLE
[fact] Make start/end of PCS lists unique nodes

### DIFF
--- a/src/main/java/se/kth/spork/cli/Cli.java
+++ b/src/main/java/se/kth/spork/cli/Cli.java
@@ -18,6 +18,8 @@ public class Cli {
     private static final Logger LOGGER = LoggerFactory.getLogger(Spoon3dmMerge.class);
 
     public static void main(String[] args) {
+        long start = System.nanoTime();
+
         if (args.length < 3 || args.length > 4) {
             usage();
             System.exit(1);
@@ -49,6 +51,8 @@ public class Cli {
         } else {
             System.out.println(prettyPrint(merged));
         }
+
+        LOGGER.info("Total time elapsed: " + (double) (System.nanoTime() - start) / 1e9 + " seconds");
     }
 
     /**

--- a/src/main/java/se/kth/spork/merge/Content.java
+++ b/src/main/java/se/kth/spork/merge/Content.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  *
  * @author Simon Larsén
  */
-public class Content<T,V> {
+public class Content<T extends ListNode,V> {
     private Pcs<T> context;
     private V value;
 

--- a/src/main/java/se/kth/spork/merge/ListNode.java
+++ b/src/main/java/se/kth/spork/merge/ListNode.java
@@ -1,0 +1,30 @@
+package se.kth.spork.merge;
+
+/**
+ * Interface describing a PCS list node.
+ *
+ * @author Simon Larsén
+ */
+public interface ListNode {
+
+    /**
+     * @return true iff this node is the dummy node at the start of a child list.
+     */
+    default boolean isStartOfList() {
+        return false;
+    }
+
+    /**
+     * @return true iff this node is the dummy node at the end of a child list.
+     */
+    default boolean isEndOfList() {
+        return false;
+    }
+
+    /**
+     * @return true iff this node is either the start or end dummy node of a child list.
+     */
+    default boolean isListEdge() {
+        return isStartOfList() || isEndOfList();
+    }
+}

--- a/src/main/java/se/kth/spork/merge/Pcs.java
+++ b/src/main/java/se/kth/spork/merge/Pcs.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
  *
  * @author Simon Larsén
  */
-public class Pcs<T> {
+public class Pcs<T extends ListNode> {
     private T root;
     private T predecessor;
     private T successor;

--- a/src/main/java/se/kth/spork/merge/TStar.java
+++ b/src/main/java/se/kth/spork/merge/TStar.java
@@ -8,7 +8,7 @@ import java.util.function.Function;
  *
  * @author Simon Larsén
  */
-public class TStar<T,V> {
+public class TStar<T extends ListNode,V> {
     private Map<T, Set<Pcs<T>>> successors;
     private Map<T, Set<Pcs<T>>> predecessors;
     private Map<T, Set<Content<T,V>>> content;
@@ -116,7 +116,7 @@ public class TStar<T,V> {
      */
     public void remove(Pcs<T> pcs) {
         T pred = pcs.getPredecessor();
-        T succ = pcs.getPredecessor();
+        T succ = pcs.getSuccessor();
 
         predecessors.get(pred).remove(pcs);
         successors.get(succ).remove(pcs);

--- a/src/main/java/se/kth/spork/merge/TdmMerge.java
+++ b/src/main/java/se/kth/spork/merge/TdmMerge.java
@@ -26,7 +26,7 @@ public class TdmMerge {
      * @param base The base revision.
      * @param delta The raw merge.
      */
-    public static <T,V> void resolveRawMerge(TStar<T,V> base, TStar<T,V> delta) {
+    public static <T extends ListNode,V> void resolveRawMerge(TStar<T,V> base, TStar<T,V> delta) {
         List<Conflict<Content<T,V>>> contentConflicts = new ArrayList<>();
 
         for (Pcs<T> pcs : delta.getStar()) {
@@ -35,7 +35,7 @@ public class TdmMerge {
             if (delta.inStructuralConflict(pcs)) // was registered in conflict as otherPcs
                 continue;
 
-            if (pcs.getPredecessor() != null) {
+            if (!pcs.getPredecessor().isListEdge()) {
                 Set<Content<T,V>> contents = delta.getContent(pcs);
                 if (contents != null && contents.size() > 1) {
                     handleContentConflict(contents, base).ifPresent(contentConflicts::add);
@@ -76,7 +76,7 @@ public class TdmMerge {
      *
      * TODO have this method modify the contents in a less dirty way
      */
-    private static <T,V> Optional<Conflict<Content<T,V>>> handleContentConflict(Set<Content<T,V>> contents, TStar<T,V> base) {
+    private static <T extends ListNode,V> Optional<Conflict<Content<T,V>>> handleContentConflict(Set<Content<T,V>> contents, TStar<T,V> base) {
         if (contents.size() > 3)
             throw new IllegalArgumentException("expected at most 3 pieces of conflicting content, got: " + contents);
 

--- a/src/main/java/se/kth/spork/merge/spoon/NodeFactory.java
+++ b/src/main/java/se/kth/spork/merge/spoon/NodeFactory.java
@@ -1,6 +1,9 @@
 package se.kth.spork.merge.spoon;
 
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.factory.ModuleFactory;
+
+import java.util.Objects;
 
 /**
  * Wraps a CtElement and stores the wrapper in the CtElement's metadata.
@@ -23,10 +26,65 @@ public class NodeFactory {
         Object wrapper = elem.getMetadata(WRAPPER_METADATA);
 
         if (wrapper == null) {
-            wrapper = new SpoonNode(elem, currentKey++);
+            wrapper = new Node(elem, currentKey++);
             elem.putMetadata(WRAPPER_METADATA, wrapper);
         }
 
         return (SpoonNode) wrapper;
+    }
+
+    /**
+     * A simple wrapper class for a Spoon CtElement. The reason it is needed is that the 3DM merge implementation
+     * uses lookup tables, and CtElements have very heavy-duty equals and hash functions. For the purpose of 3DM merge,
+     * only reference equality is needed, not deep equality.
+     *
+     * This class should only be instantiated with the CtWrapperFactory singleton.
+     */
+    private static class Node implements SpoonNode {
+        private final CtElement element;
+        private final long key;
+
+        Node(CtElement element, long key) {
+            this.element = element;
+            this.key = key;
+        }
+
+        @Override
+        public CtElement getElement() {
+            return element;
+        }
+
+        @Override
+        public SpoonNode getParent() {
+            if (element instanceof ModuleFactory.CtUnnamedModule)
+                return null;
+            return wrap(element.getParent());
+        }
+
+        @Override
+        public String toString() {
+            if (element == null)
+                return "null";
+
+            String longRep = element.toString();
+            if (longRep.contains("\n")) {
+                String[] shortRep = element.getShortRepresentation().split("\\.");
+                return shortRep[shortRep.length - 1];
+            }
+            return longRep;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Node wrapper = (Node) o;
+            return key == wrapper.key;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key);
+        }
     }
 }

--- a/src/main/java/se/kth/spork/merge/spoon/NodeFactory.java
+++ b/src/main/java/se/kth/spork/merge/spoon/NodeFactory.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 public class NodeFactory {
     public static final String WRAPPER_METADATA = "spork_wrapper";
     private static long currentKey = 0;
+    public static final SpoonNode ROOT = new Root();
 
     /**
      * Wrap a CtElement in a CtWrapper. The wrapper is stored in the CtElement's metadata. If a CtElement that has
@@ -31,6 +32,26 @@ public class NodeFactory {
         }
 
         return (SpoonNode) wrapper;
+    }
+
+    /**
+     * Create a node that represents the start of the child list of the provided node.
+     *
+     * @param node A Spoon node.
+     * @return The start of the child list of the given node.
+     */
+    public static SpoonNode startOfChildList(SpoonNode node) {
+        return new ListEdge(node, ListEdge.Side.START);
+    }
+
+    /**
+     * Create a node that represents the end of the child list of the provided node.
+     *
+     * @param elem A Spoon node.
+     * @return The end of the child list of the given node.
+     */
+    public static SpoonNode endOfChildList(SpoonNode elem) {
+        return new ListEdge(elem, ListEdge.Side.END);
     }
 
     /**
@@ -57,7 +78,7 @@ public class NodeFactory {
         @Override
         public SpoonNode getParent() {
             if (element instanceof ModuleFactory.CtUnnamedModule)
-                return null;
+                return NodeFactory.ROOT;
             return wrap(element.getParent());
         }
 
@@ -85,6 +106,80 @@ public class NodeFactory {
         @Override
         public int hashCode() {
             return Objects.hash(key);
+        }
+    }
+
+    private static class Root implements SpoonNode {
+        @Override
+        public CtElement getElement() {
+            return null;
+        }
+
+        @Override
+        public SpoonNode getParent() {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "ROOT";
+        }
+    }
+
+    /**
+     * A special SpoonNode that marks the start or end of a child list.
+     */
+    private static class ListEdge implements SpoonNode {
+        private enum Side {
+            START, END;
+        }
+
+        // the parent of the child list
+        private SpoonNode parent;
+        private Side side;
+
+        ListEdge(SpoonNode parent, Side side) {
+            this.parent = parent;
+            this.side = side;
+        }
+
+        @Override
+        public CtElement getElement() {
+            return null;
+        }
+
+        @Override
+        public SpoonNode getParent() {
+            return parent;
+        }
+
+        @Override
+        public boolean isEndOfList() {
+            return side == Side.END;
+        }
+
+        @Override
+        public boolean isStartOfList() {
+            return side == Side.START;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ListEdge listEdge = (ListEdge) o;
+            return Objects.equals(parent, listEdge.parent) &&
+                    side == listEdge.side;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(parent, side);
+        }
+
+        @Override
+        public String toString() {
+            return side.toString();
         }
     }
 }

--- a/src/main/java/se/kth/spork/merge/spoon/PcsBuilder.java
+++ b/src/main/java/se/kth/spork/merge/spoon/PcsBuilder.java
@@ -30,7 +30,7 @@ class PcsBuilder extends CtScanner {
             root = wrapped;
 
         SpoonNode parent = wrapped.getParent();
-        SpoonNode predecessor = rootTolastSibling.get(parent);
+        SpoonNode predecessor = rootTolastSibling.getOrDefault(parent, NodeFactory.startOfChildList(wrapped.getParent()));
         pcses.add(newPcs(parent, predecessor, wrapped, revision));
         rootTolastSibling.put(parent, wrapped);
     }
@@ -47,7 +47,7 @@ class PcsBuilder extends CtScanner {
      */
     private void finalizePcsLists() {
         for (SpoonNode predecessor : rootTolastSibling.values()) {
-            pcses.add(newPcs(predecessor.getParent(), predecessor, null, revision));
+            pcses.add(newPcs(predecessor.getParent(), predecessor, NodeFactory.endOfChildList(predecessor.getParent()), revision));
         }
     }
 

--- a/src/main/java/se/kth/spork/merge/spoon/SpoonNode.java
+++ b/src/main/java/se/kth/spork/merge/spoon/SpoonNode.java
@@ -1,8 +1,9 @@
 package se.kth.spork.merge.spoon;
 
+import se.kth.spork.merge.ListNode;
 import spoon.reflect.declaration.CtElement;
 
-public interface SpoonNode {
+public interface SpoonNode extends ListNode {
     CtElement getElement();
 
     SpoonNode getParent();

--- a/src/main/java/se/kth/spork/merge/spoon/SpoonNode.java
+++ b/src/main/java/se/kth/spork/merge/spoon/SpoonNode.java
@@ -1,59 +1,9 @@
 package se.kth.spork.merge.spoon;
 
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.factory.ModuleFactory;
 
-import java.util.Objects;
+public interface SpoonNode {
+    CtElement getElement();
 
-/**
- * A simple wrapper class for a Spoon CtElement. The reason it is needed is that the 3DM merge implementation
- * uses lookup tables, and CtElements have very heavy-duty equals and hash functions. For the purpose of 3DM merge,
- * only reference equality is needed, not deep equality.
- *
- * This class should only be instantiated with the CtWrapperFactory singleton.
- */
-public class SpoonNode {
-    private final CtElement element;
-    private final long key;
-
-    SpoonNode(CtElement element, long key) {
-        this.element = element;
-        this.key = key;
-    }
-
-    public CtElement getElement() {
-        return element;
-    }
-
-    public SpoonNode getParent() {
-        if (element instanceof ModuleFactory.CtUnnamedModule)
-            return null;
-        return NodeFactory.wrap(element.getParent());
-    }
-
-    @Override
-    public String toString() {
-        if (element == null)
-            return "null";
-
-        String longRep = element.toString();
-        if (longRep.contains("\n")) {
-            String[] shortRep = element.getShortRepresentation().split("\\.");
-            return shortRep[shortRep.length - 1];
-        }
-        return longRep;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SpoonNode wrapper = (SpoonNode) o;
-        return key == wrapper.key;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(key);
-    }
+    SpoonNode getParent();
 }


### PR DESCRIPTION
Fix #26 

This PR makes starts and ends of PCS lists unique nodes that depend on the parent. So, in concept, a PCS triple that previously looked like `Pcs(a, null, b)` will now look like `Pcs(a, START(a), b)`. All elements of PCS triples are now non-null.

This essentially solves all performance problems with the actual merge, as computed by the `TdmMerge` class, it's now super fast. Previously, merging a ~2000 line Java file would take around 7-8 seconds, while now it takes roughly 0.1 seconds.

The total time for a merge of a file that size sits around 3-4 seconds, half of which is parsing Java files to Spoon trees.