### PR TITLE
[fix] Handle modifiers

### DIFF
--- a/src/main/java/se/kth/spork/base3dm/TStar.java
+++ b/src/main/java/se/kth/spork/base3dm/TStar.java
@@ -90,7 +90,7 @@ public class TStar<T extends ListNode,V> {
      * @return The content associated with the argument's predecessor node.
      */
     public Set<Content<T,V>> getContent(Pcs<T> pcs) {
-        return content.get(pcs.getPredecessor());
+        return Collections.unmodifiableSet(content.get(pcs.getPredecessor()));
     }
 
     /**
@@ -108,6 +108,16 @@ public class TStar<T extends ListNode,V> {
      */
     public boolean contains(Content<T,V> cont) {
         return content.getOrDefault(cont.getContext().getPredecessor(), new HashSet<>()).contains(cont);
+    }
+
+    /**
+     * Set the content for some pcs triple, overwriting anything that was there previously.
+     *
+     * @param pcs A PCS triple.
+     * @param nodeContents A set of content values to associate with the node.
+     */
+    public void setContent(Pcs<T> pcs, Set<Content<T, V>> nodeContents) {
+        content.put(pcs.getPredecessor(), nodeContents);
     }
 
     /**

--- a/src/main/java/se/kth/spork/base3dm/TStar.java
+++ b/src/main/java/se/kth/spork/base3dm/TStar.java
@@ -16,8 +16,11 @@ public class TStar<T extends ListNode,V> {
     private Set<Pcs<T>> star;
     private Map<Pcs<T>, Set<Pcs<T>>> structuralConflicts;
 
-    // never add anything to this set!
-    private final Set<Pcs<T>> EMPTY_PCS_SET = new HashSet<>();
+    @SuppressWarnings("unchecked")
+    private final Set<Pcs<T>> EMPTY_PCS_SET = Collections.EMPTY_SET;
+
+    @SuppressWarnings("unchecked")
+    private final Set<Content<T,V>> EMPTY_CONTENT_SET = Collections.EMPTY_SET;
 
     /**
      * Create a T* from the provided trees, using the class representatives map to map each node to its class
@@ -86,11 +89,11 @@ public class TStar<T extends ListNode,V> {
     }
 
     /**
-     * @param pcs A PCS triple.
-     * @return The content associated with the argument's predecessor node.
+     * @param node A node..
+     * @return The content associated with the argument node, or an empty set if no content was associated.
      */
-    public Set<Content<T,V>> getContent(Pcs<T> pcs) {
-        return Collections.unmodifiableSet(content.get(pcs.getPredecessor()));
+    public Set<Content<T,V>> getContent(T node) {
+        return Collections.unmodifiableSet(content.getOrDefault(node, EMPTY_CONTENT_SET));
     }
 
     /**
@@ -113,11 +116,11 @@ public class TStar<T extends ListNode,V> {
     /**
      * Set the content for some pcs triple, overwriting anything that was there previously.
      *
-     * @param pcs A PCS triple.
+     * @param node A node to associate the content with. This is the key in the backing map.
      * @param nodeContents A set of content values to associate with the node.
      */
-    public void setContent(Pcs<T> pcs, Set<Content<T, V>> nodeContents) {
-        content.put(pcs.getPredecessor(), nodeContents);
+    public void setContent(T node, Set<Content<T, V>> nodeContents) {
+        content.put(node, nodeContents);
     }
 
     /**
@@ -189,7 +192,7 @@ public class TStar<T extends ListNode,V> {
                 addToLookupTable(classRepPred, classRepPcs, predecessors);
                 addToLookupTable(classRepSucc, classRepPcs, successors);
             }
-            if (pred != null) {
+            if (!pred.isListEdge()) {
                 Content<T,V> c = new Content<T,V>(pcs, getContent.apply(pred));
                 addToLookupTable(classRepPred, c, content);
             }

--- a/src/main/java/se/kth/spork/base3dm/TdmMerge.java
+++ b/src/main/java/se/kth/spork/base3dm/TdmMerge.java
@@ -36,7 +36,8 @@ public class TdmMerge {
             if (!pcs.getPredecessor().isListEdge()) {
                 Set<Content<T,V>> contents = delta.getContent(pcs);
                 if (contents != null && contents.size() > 1) {
-                    handleContentConflict(contents, base);
+                    Set<Content<T,V>> newContent = handleContentConflict(contents, base);
+                    delta.setContent(pcs, newContent);
                 }
             }
 
@@ -69,40 +70,50 @@ public class TdmMerge {
     /**
      * Handle content conflicts, i.e. the same node is associated with multiple (potentially equivalent) contents.
      *
-     * TODO have this method modify the contents in a less dirty way
+     * If the conflict can be automatically resolved, the new contents (with only one piece of content) are returned.
+     *
+     * If the content conflict cannot be automatically resolved, the contents argument is simply returned as-is.
      */
-    private static <T extends ListNode,V> void handleContentConflict(Set<Content<T,V>> contents, TStar<T,V> base) {
+    private static <T extends ListNode,V> Set<Content<T,V>> handleContentConflict(Set<Content<T,V>> contents, TStar<T,V> base) {
         if (contents.size() > 3)
             throw new IllegalArgumentException("expected at most 3 pieces of conflicting content, got: " + contents);
+
+        Set<Content<T,V>> newContent = new HashSet<>(contents);
 
         // contents equal to that in base never takes precedence over left and right revisions
         Optional<Content<T,V>> basePcsOpt = contents.stream().filter(base::contains).findAny();
 
-        basePcsOpt.ifPresent(content -> contents.removeIf(c -> Objects.equals(c.getValue(), content.getValue())));
+        basePcsOpt.ifPresent(content -> newContent.removeIf(c -> Objects.equals(c.getValue(), content.getValue())));
 
-        if (contents.size() == 0) { // everything was equal to base, re-add
-            contents.add(basePcsOpt.get());
-        } else if (contents.size() == 2) { // both left and right have been modified from base
-            Iterator<Content<T,V>> it = contents.iterator();
+        if (newContent.size() == 0) { // everything was equal to base, re-add
+            newContent.add(basePcsOpt.get());
+        } else if (newContent.size() == 2) { // both left and right have been modified from base
+            Iterator<Content<T,V>> it = newContent.iterator();
             Content<T,V> first = it.next();
             Content<T,V> second = it.next();
             if (second.getValue().equals(first.getValue()))
                 it.remove();
-        } else if (contents.size() > 2) {
+        } else if (newContent.size() > 2) {
             // This should never happen, as there are at most 3 pieces of content to begin with and base has been
             // removed.
-            throw new IllegalStateException("Unexpected amount of conflicting content: " + contents);
+            throw new IllegalStateException("Unexpected amount of conflicting content: " + newContent);
         }
 
-        if (contents.size() != 1) {
-            // there was new content both in left and right revisions that was not equal
+        if (newContent.size() != 1) {
+            // conflict could not be resolved
 
-            Iterator<Content<T,V>> it = contents.iterator();
+            Iterator<Content<T,V>> it = newContent.iterator();
             Content<T,V> first = it.next();
             Content<T,V> second = it.next();
 
             LOGGER.warn("Content conflict: " + first + ", " + second);
+
+            // the reason all content is returned is that further processing of conflicts may be done after the base
+            // 3DM merge has finished, which may require the content of all revisions
+            return contents;
         }
+
+        return newContent;
     }
 
 }

--- a/src/main/java/se/kth/spork/base3dm/TdmMerge.java
+++ b/src/main/java/se/kth/spork/base3dm/TdmMerge.java
@@ -34,10 +34,10 @@ public class TdmMerge {
                 continue;
 
             if (!pcs.getPredecessor().isListEdge()) {
-                Set<Content<T,V>> contents = delta.getContent(pcs);
+                Set<Content<T,V>> contents = delta.getContent(pcs.getPredecessor());
                 if (contents != null && contents.size() > 1) {
                     Set<Content<T,V>> newContent = handleContentConflict(contents, base);
-                    delta.setContent(pcs, newContent);
+                    delta.setContent(pcs.getPredecessor(), newContent);
                 }
             }
 

--- a/src/main/java/se/kth/spork/cli/Cli.java
+++ b/src/main/java/se/kth/spork/cli/Cli.java
@@ -61,7 +61,7 @@ public class Cli {
      * @param spoonRoot Root of a merged Spoon tree.
      * @return A pretty-printed string representing the merged output.
      */
-    static String prettyPrint(CtModule spoonRoot) {
+    public static String prettyPrint(CtModule spoonRoot) {
         CtPackage activePackage = spoonRoot.getRootPackage();
         while (!activePackage.getPackages().isEmpty()) {
             assert activePackage.getPackages().size() == 1;

--- a/src/main/java/se/kth/spork/spoon/PcsInterpreter.java
+++ b/src/main/java/se/kth/spork/spoon/PcsInterpreter.java
@@ -449,6 +449,12 @@ public class PcsInterpreter {
             if (roledValue.getRole() != null) {
                 mergeTree.setValueByRole(roledValue.getRole(), roledValue.getValue());
             }
+
+            if (roledValue.hasSecondaryValues()) {
+                for (RoledValue secondary : roledValue.getSecondaryValues()) {
+                    mergeTree.setValueByRole(secondary.getRole(), secondary.getValue());
+                }
+            }
         }
 
         /**

--- a/src/main/java/se/kth/spork/spoon/RoledValue.java
+++ b/src/main/java/se/kth/spork/spoon/RoledValue.java
@@ -2,6 +2,9 @@ package se.kth.spork.spoon;
 
 import spoon.reflect.path.CtRole;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -14,9 +17,13 @@ class RoledValue {
     private final Object value;
     private final CtRole role;
 
+    // secondary values can be, for example, modifiers for classes and fields or bounds on type parameters
+    private List<RoledValue> secondaryValues;
+
     public RoledValue(Object value, CtRole role) {
         this.value = value;
         this.role = role;
+        this.secondaryValues = new ArrayList<>();
     }
 
     public Object getValue() {
@@ -27,13 +34,26 @@ class RoledValue {
         return role;
     }
 
+    public void addSecondaryValue(Object value, CtRole role) {
+        secondaryValues.add(new RoledValue(value, role));
+    }
+
+    public List<RoledValue> getSecondaryValues() {
+        return Collections.unmodifiableList(secondaryValues);
+    }
+
+    public boolean hasSecondaryValues() {
+        return !secondaryValues.isEmpty();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RoledValue roledValue1 = (RoledValue) o;
         return role == roledValue1.role &&
-                Objects.equals(value, roledValue1.value);
+                Objects.equals(value, roledValue1.value) &&
+                Objects.equals(secondaryValues, roledValue1.secondaryValues);
     }
 
     @Override

--- a/src/main/java/se/kth/spork/spoon/RoledValue.java
+++ b/src/main/java/se/kth/spork/spoon/RoledValue.java
@@ -2,10 +2,8 @@ package se.kth.spork.spoon;
 
 import spoon.reflect.path.CtRole;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Class representing some form of value in a Spoon node, along with the role the value has. This is for
@@ -44,6 +42,14 @@ class RoledValue {
 
     public boolean hasSecondaryValues() {
         return !secondaryValues.isEmpty();
+    }
+
+    public RoledValue getSecondaryByRole(CtRole role) {
+        Optional<RoledValue> val = secondaryValues.stream().filter(v -> v.getRole() == role).findFirst();
+        if (!val.isPresent()) {
+            throw new RuntimeException("No secondary value with role " + role);
+        }
+        return val.get();
     }
 
     @Override

--- a/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
+++ b/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
@@ -14,13 +14,10 @@ import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtOperatorAssignment;
 import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtImport;
-import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.*;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtReference;
 
-import javax.management.relation.Role;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
@@ -166,6 +163,13 @@ public class Spoon3dmMerge {
                 return null;
 
             CtElement elem = wrapper.getElement();
+            RoledValue rv = extractPrimaryValue(elem);
+            attachSecondaryValues(elem, rv);
+
+            return rv;
+        }
+
+        private static RoledValue extractPrimaryValue(CtElement elem) {
             if (elem instanceof CtLiteral) {
                 CtLiteral<?> lit = (CtLiteral<?>) elem;
                 return new RoledValue(lit.getValue(), CtRole.VALUE);
@@ -185,7 +189,16 @@ public class Spoon3dmMerge {
                 CtUnaryOperator<?> op = (CtUnaryOperator<?>) elem;
                 return new RoledValue(op.getKind(), CtRole.OPERATOR_KIND);
             }
+
             return new RoledValue(elem.getShortRepresentation(), null);
+        }
+
+        private static void attachSecondaryValues(CtElement elem, RoledValue rv) {
+            if (elem instanceof CtModifiable) {
+                CtModifiable mod = (CtModifiable) elem;
+                Set<ModifierKind> modifiers = new HashSet<>(mod.getModifiers());
+                rv.addSecondaryValue(modifiers, CtRole.MODIFIER);
+            }
         }
     }
 

--- a/src/main/java/se/kth/spork/util/Triple.java
+++ b/src/main/java/se/kth/spork/util/Triple.java
@@ -1,0 +1,18 @@
+package se.kth.spork.util;
+
+/**
+ * A simple generic container for three values of potentially different types.
+ *
+ * @author Simon Larsén
+ */
+public class Triple<T,K,V> {
+    public final T first;
+    public final K second;
+    public final V third;
+
+    public Triple(T first, K second, V third) {
+        this.first = first;
+        this.second = second;
+        this.third = third;
+    }
+}

--- a/src/test/java/se/kth/spork/cli/CliTest.java
+++ b/src/test/java/se/kth/spork/cli/CliTest.java
@@ -89,6 +89,7 @@ class CliTest {
             "add_import_statements",
             "change_binops",
             "change_unary_ops",
+            "add_field_modifiers",
     })
     void mergeTreeShouldEqualReParsedPrettyPrent_whenBothRevisionsAreModified(String testName, @TempDir Path tempDir) throws IOException {
         File testDir = Util.BOTH_MODIFIED_DIRPATH.resolve(testName).toFile();

--- a/src/test/java/se/kth/spork/cli/CliTest.java
+++ b/src/test/java/se/kth/spork/cli/CliTest.java
@@ -39,6 +39,8 @@ class CliTest {
             "edit_annotations",
             "change_package_statement",
             "generify_method",
+            "add_class_visibility",
+            "change_field_modifiers",
     })
     void mergeTreeShouldEqualReParsedPrettyPrint_whenLeftIsModified(
             String testName, @TempDir Path tempDir) throws IOException {
@@ -66,6 +68,8 @@ class CliTest {
             "edit_annotations",
             "change_package_statement",
             "generify_method",
+            "add_class_visibility",
+            "change_field_modifiers",
     })
     void mergeTreeShouldEqualReParsedPrettyPrint_whenRightIsModified(
             String testName, @TempDir Path tempDir) throws IOException {

--- a/src/test/java/se/kth/spork/spoon/Spoon3dmMergeTest.java
+++ b/src/test/java/se/kth/spork/spoon/Spoon3dmMergeTest.java
@@ -87,6 +87,7 @@ class Spoon3dmMergeTest {
             "add_import_statements",
             "change_binops",
             "change_unary_ops",
+            "add_field_modifiers",
     })
     void mergeToTree_shouldReturnExpectedTree_whenBothVersionsAreModified(String testName) throws IOException {
         File testDir = Util.BOTH_MODIFIED_DIRPATH.resolve(testName).toFile();

--- a/src/test/java/se/kth/spork/spoon/Spoon3dmMergeTest.java
+++ b/src/test/java/se/kth/spork/spoon/Spoon3dmMergeTest.java
@@ -34,6 +34,8 @@ class Spoon3dmMergeTest {
             "edit_annotations",
             "change_package_statement",
             "generify_method",
+            "add_class_visibility",
+            "change_field_modifiers",
     })
     void mergeToTree_shouldReturnExpectedTree_whenLeftVersionIsModified(String testName) {
         File testDir = Util.LEFT_MODIFIED_DIRPATH.resolve(testName).toFile();
@@ -60,6 +62,8 @@ class Spoon3dmMergeTest {
             "edit_annotations",
             "change_package_statement",
             "generify_method",
+            "add_class_visibility",
+            "change_field_modifiers",
     })
     void mergeToTree_shouldReturnExpectedTree_whenRightVersionIsModified(String testName) {
         File testDir = Util.LEFT_MODIFIED_DIRPATH.resolve(testName).toFile();
@@ -98,6 +102,11 @@ class Spoon3dmMergeTest {
         CtElement merged = Spoon3dmMerge.merge(sources.base, sources.left, sources.right);
         Object mergedImports = merged.getMetadata(Parser.IMPORT_STATEMENTS);
 
+        // this assert is just to give a better overview of obvious errors, but it relies on the pretty printer's
+        // correctness
+        assertEquals(Cli.prettyPrint((CtModule) expected), Cli.prettyPrint((CtModule) merged));
+
+        // these asserts are what actually matters
         assertEquals(expected, merged);
         assertEquals(expectedImports, mergedImports);
     }

--- a/src/test/resources/clean/both_modified/add_field_modifiers/Base.java
+++ b/src/test/resources/clean/both_modified/add_field_modifiers/Base.java
@@ -1,0 +1,3 @@
+public class Cls {
+    private int x = 0;
+}

--- a/src/test/resources/clean/both_modified/add_field_modifiers/Expected.java
+++ b/src/test/resources/clean/both_modified/add_field_modifiers/Expected.java
@@ -1,0 +1,3 @@
+public class Cls {
+    private static final int x = 0;
+}

--- a/src/test/resources/clean/both_modified/add_field_modifiers/Left.java
+++ b/src/test/resources/clean/both_modified/add_field_modifiers/Left.java
@@ -1,0 +1,3 @@
+public class Cls {
+    private static int x = 0;
+}

--- a/src/test/resources/clean/both_modified/add_field_modifiers/Right.java
+++ b/src/test/resources/clean/both_modified/add_field_modifiers/Right.java
@@ -1,0 +1,3 @@
+public class Cls {
+    private final int x = 0;
+}

--- a/src/test/resources/clean/left_modified/add_class_visibility/Base.java
+++ b/src/test/resources/clean/left_modified/add_class_visibility/Base.java
@@ -1,0 +1,3 @@
+class Cls {
+
+}

--- a/src/test/resources/clean/left_modified/add_class_visibility/Expected.java
+++ b/src/test/resources/clean/left_modified/add_class_visibility/Expected.java
@@ -1,0 +1,3 @@
+public class Cls {
+
+}

--- a/src/test/resources/clean/left_modified/add_class_visibility/Left.java
+++ b/src/test/resources/clean/left_modified/add_class_visibility/Left.java
@@ -1,0 +1,3 @@
+public class Cls {
+
+}

--- a/src/test/resources/clean/left_modified/add_class_visibility/Right.java
+++ b/src/test/resources/clean/left_modified/add_class_visibility/Right.java
@@ -1,0 +1,3 @@
+class Cls {
+
+}

--- a/src/test/resources/clean/left_modified/change_field_modifiers/Base.java
+++ b/src/test/resources/clean/left_modified/change_field_modifiers/Base.java
@@ -1,0 +1,3 @@
+public class Cls {
+    private int x = 0;
+}

--- a/src/test/resources/clean/left_modified/change_field_modifiers/Expected.java
+++ b/src/test/resources/clean/left_modified/change_field_modifiers/Expected.java
@@ -1,0 +1,3 @@
+public class Cls {
+    public static final int x = 0;
+}

--- a/src/test/resources/clean/left_modified/change_field_modifiers/Left.java
+++ b/src/test/resources/clean/left_modified/change_field_modifiers/Left.java
@@ -1,0 +1,3 @@
+public class Cls {
+    public static final int x = 0;
+}

--- a/src/test/resources/clean/left_modified/change_field_modifiers/Right.java
+++ b/src/test/resources/clean/left_modified/change_field_modifiers/Right.java
@@ -1,0 +1,3 @@
+public class Cls {
+    private int x = 0;
+}


### PR DESCRIPTION
Fix #36 
Fix #39 

This PR is a start for addressing the problem that some nodes have many values associated with them. It introduces the notion that there's a _primary_ value (e.g. the name of a method or field), and _secondary_ values (e.g. modifiers).

As conflicts related to secondary values can't be resolved during the base 3DM merge without introducing significant complexity, they are resolved after that, in the `Spoon3dmMerge` class. Currently, only conflicts that can be automatically resolved are handled properly. Conflicts that can't be automatically resolved will lead to the _primary_ value being flagged as conflicting.

This means that a new way of handling content conflicts must be introduced.