### PR TITLE
[feat] Automatically resolve ordering conflicts

### DIFF
--- a/src/test/java/se/kth/spork/cli/CliTest.java
+++ b/src/test/java/se/kth/spork/cli/CliTest.java
@@ -90,6 +90,8 @@ class CliTest {
             "change_binops",
             "change_unary_ops",
             "add_field_modifiers",
+            "method_method_ordering_conflict",
+            "multiple_method_ordering_conflicts",
     })
     void mergeTreeShouldEqualReParsedPrettyPrent_whenBothRevisionsAreModified(String testName, @TempDir Path tempDir) throws IOException {
         File testDir = Util.BOTH_MODIFIED_DIRPATH.resolve(testName).toFile();

--- a/src/test/resources/clean/both_modified/method_method_ordering_conflict/Base.java
+++ b/src/test/resources/clean/both_modified/method_method_ordering_conflict/Base.java
@@ -1,0 +1,17 @@
+public class Sum {
+    public int sumBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int sum = 0;
+        for (int i = a; i < b; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private void checkBounds(int a, int b) {
+        if (b <= a) {
+            throw new IllegalArgumentException("b must be greater than or equal to a");
+        }
+    }
+}

--- a/src/test/resources/clean/both_modified/method_method_ordering_conflict/Expected.java
+++ b/src/test/resources/clean/both_modified/method_method_ordering_conflict/Expected.java
@@ -1,0 +1,43 @@
+public class Sum {
+    public int sumBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int sum = 0;
+        for (int i = a; i < b; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private int sumTo(int to) {
+        checkToBound(to);
+        int sum = 0;
+        for (int i = 0; i < to; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private void checkToBound(int to) {
+        if (to >= 1_000) {
+            throw new IllegalArgumentException("I can't count that high: " + to);
+        }
+    }
+
+    private int multiplyBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int prod = 1;
+        for (int i = a; i < b; i++) {
+            prod *= i;
+        }
+
+        return prod;
+    }
+
+    private void checkBounds(int a, int b) {
+        if (b <= a) {
+            throw new IllegalArgumentException("b must be greater than or equal to a");
+        }
+    }
+}

--- a/src/test/resources/clean/both_modified/method_method_ordering_conflict/Left.java
+++ b/src/test/resources/clean/both_modified/method_method_ordering_conflict/Left.java
@@ -1,0 +1,32 @@
+public class Sum {
+    public int sumBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int sum = 0;
+        for (int i = a; i < b; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private int sumTo(int to) {
+        checkToBound(to);
+        int sum = 0;
+        for (int i = 0; i < to; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private void checkToBound(int to) {
+        if (to >= 1_000) {
+            throw new IllegalArgumentException("I can't count that high: " + to);
+        }
+    }
+
+    private void checkBounds(int a, int b) {
+        if (b <= a) {
+            throw new IllegalArgumentException("b must be greater than or equal to a");
+        }
+    }
+}

--- a/src/test/resources/clean/both_modified/method_method_ordering_conflict/Right.java
+++ b/src/test/resources/clean/both_modified/method_method_ordering_conflict/Right.java
@@ -1,0 +1,28 @@
+public class Sum {
+    public int sumBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int sum = 0;
+        for (int i = a; i < b; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private int multiplyBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int prod = 1;
+        for (int i = a; i < b; i++) {
+            prod *= i;
+        }
+
+        return prod;
+    }
+
+    private void checkBounds(int a, int b) {
+        if (b <= a) {
+            throw new IllegalArgumentException("b must be greater than or equal to a");
+        }
+    }
+}

--- a/src/test/resources/clean/both_modified/multiple_method_ordering_conflicts/Base.java
+++ b/src/test/resources/clean/both_modified/multiple_method_ordering_conflicts/Base.java
@@ -1,0 +1,17 @@
+public class Sum {
+    public int sumBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int sum = 0;
+        for (int i = a; i < b; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private void checkBounds(int a, int b) {
+        if (b <= a) {
+            throw new IllegalArgumentException("b must be greater than or equal to a");
+        }
+    }
+}

--- a/src/test/resources/clean/both_modified/multiple_method_ordering_conflicts/Expected.java
+++ b/src/test/resources/clean/both_modified/multiple_method_ordering_conflicts/Expected.java
@@ -1,0 +1,53 @@
+public class Sum {
+    public int sumBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int sum = 0;
+        for (int i = a; i < b; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private int sumTo(int to) {
+        checkToBound(to);
+        int sum = 0;
+        for (int i = 0; i < to; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private void checkToBound(int to) {
+        if (to >= 1_000) {
+            throw new IllegalArgumentException("I can't count that high: " + to);
+        }
+    }
+
+    private int multiplyBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int prod = 1;
+        for (int i = a; i < b; i++) {
+            prod *= i;
+        }
+
+        return prod;
+    }
+
+    private void checkBounds(int a, int b) {
+        if (b <= a) {
+            throw new IllegalArgumentException("b must be greater than or equal to a");
+        }
+    }
+
+    public int sumAndMultiplyBetween(int a, int b) {
+        int sum = sumBetween(a, b):
+        int prod = multiplyBetween(a, b);
+        return sum + prod;
+    }
+
+    public int sumBetweenUndirected(int a, int b) {
+        return a <= b ? sumBetween(a, b) : sumBetween(b, a);
+    }
+}

--- a/src/test/resources/clean/both_modified/multiple_method_ordering_conflicts/Left.java
+++ b/src/test/resources/clean/both_modified/multiple_method_ordering_conflicts/Left.java
@@ -1,0 +1,36 @@
+public class Sum {
+    public int sumBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int sum = 0;
+        for (int i = a; i < b; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private int sumTo(int to) {
+        checkToBound(to);
+        int sum = 0;
+        for (int i = 0; i < to; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private void checkToBound(int to) {
+        if (to >= 1_000) {
+            throw new IllegalArgumentException("I can't count that high: " + to);
+        }
+    }
+
+    private void checkBounds(int a, int b) {
+        if (b <= a) {
+            throw new IllegalArgumentException("b must be greater than or equal to a");
+        }
+    }
+
+    public int sumBetweenUndirected(int a, int b) {
+        return a <= b ? sumBetween(a, b) : sumBetween(b, a);
+    }
+}

--- a/src/test/resources/clean/both_modified/multiple_method_ordering_conflicts/Right.java
+++ b/src/test/resources/clean/both_modified/multiple_method_ordering_conflicts/Right.java
@@ -1,0 +1,34 @@
+public class Sum {
+    public int sumBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int sum = 0;
+        for (int i = a; i < b; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private int multiplyBetween(int a, int b) {
+        checkBounds(a, b);
+
+        int prod = 1;
+        for (int i = a; i < b; i++) {
+            prod *= i;
+        }
+
+        return prod;
+    }
+
+    private void checkBounds(int a, int b) {
+        if (b <= a) {
+            throw new IllegalArgumentException("b must be greater than or equal to a");
+        }
+    }
+
+    public int sumAndMultiplyBetween(int a, int b) {
+        int sum = sumBetween(a, b):
+        int prod = multiplyBetween(a, b);
+        return sum + prod;
+    }
+}


### PR DESCRIPTION
Fix #5 

This is a very liberal interpretation of ordering conflicts. Any type member of a class is considered unordered, which technically isn't the case for fields as they may have dependencies on each other.