### PR TITLE
[fix] Deal properly with comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
             <artifactId>picocli</artifactId>
             <version>4.2.0</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit -->
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>5.6.1.202002131546-r</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/se/kth/spork/cli/SporkPrettyPrinter.java
+++ b/src/main/java/se/kth/spork/cli/SporkPrettyPrinter.java
@@ -10,15 +10,11 @@ import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.*;
-import spoon.reflect.visitor.printer.CommentOffset;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.List;
-import java.util.Optional;
-import java.util.SortedMap;
 
 public class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
     public static final String START_CONFLICT = "<<<<<<< LEFT";
@@ -27,6 +23,10 @@ public class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
 
     public SporkPrettyPrinter(Environment env) {
         super(env);
+
+        // this line is SUPER important because without it implicit elements will be printed. For example,
+        // instead of just String, it will print java.lang.String. Which isn't great.
+        setIgnoreImplicit(false);
     }
 
     @Override

--- a/src/main/java/se/kth/spork/cli/SporkPrettyPrinter.java
+++ b/src/main/java/se/kth/spork/cli/SporkPrettyPrinter.java
@@ -1,45 +1,69 @@
 package se.kth.spork.cli;
 
+import se.kth.spork.spoon.ContentConflict;
+import se.kth.spork.spoon.RoledValue;
 import se.kth.spork.spoon.StructuralConflict;
+import se.kth.spork.util.LineBasedMerge;
 import spoon.compiler.Environment;
+import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
-import spoon.reflect.visitor.PrinterHelper;
-import spoon.reflect.visitor.TokenWriter;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.visitor.*;
+import spoon.reflect.visitor.printer.CommentOffset;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Optional;
+import java.util.SortedMap;
 
 public class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
     public static final String START_CONFLICT = "<<<<<<< LEFT";
     public static final String MID_CONFLICT = "=======";
     public static final String END_CONFLICT = ">>>>>>> RIGHT";
 
-    /**
-     * Creates a new code generator visitor.
-     *
-     * @param env
-     */
     public SporkPrettyPrinter(Environment env) {
         super(env);
-        setIgnoreImplicit(false);
     }
 
     @Override
     public SporkPrettyPrinter scan(CtElement e) {
-        if (e == null || !e.getMetadataKeys().contains(StructuralConflict.STRUCTURAL_CONFLICT_METADATA_KEY)) {
-            super.scan(e);
+        if (e == null)
             return this;
+
+        StructuralConflict structuralConflict = (StructuralConflict) e.getMetadata(StructuralConflict.METADATA_KEY);
+
+        if (structuralConflict != null) {
+            writeStructuralConflict(structuralConflict);
+        } else {
+            super.scan(e);
         }
 
-        StructuralConflict structuralConflict =
-                (StructuralConflict) e.getMetadata( StructuralConflict.STRUCTURAL_CONFLICT_METADATA_KEY);
-        writeStructuralConflict(structuralConflict);
-
         return this;
+    }
+
+    @Override
+    public void visitCtComment(CtComment comment) {
+        @SuppressWarnings("unchecked")
+        List<ContentConflict> contentConflicts = (List<ContentConflict>) comment.getMetadata(
+                ContentConflict.METADATA_KEY);
+        if (contentConflicts != null) {
+            ContentConflict contents = contentConflicts.stream().filter(c -> c.getRole() == CtRole.COMMENT_CONTENT)
+                    .findFirst().get();
+
+            String rawLeft = (String) contents.getLeft().getMetadata(RoledValue.Key.RAW_CONTENT);
+            String rawRight = (String) contents.getRight().getMetadata(RoledValue.Key.RAW_CONTENT);
+            String rawBase = contents.getBase().isPresent() ?
+                    (String) contents.getBase().get().getMetadata(RoledValue.Key.RAW_CONTENT) : "";
+
+            String merged = LineBasedMerge.merge(rawBase, rawLeft, rawRight);
+            writeAtLeftMargin(merged);
+        } else {
+            super.visitCtComment(comment);
+        }
     }
 
     /**
@@ -48,19 +72,30 @@ public class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
     private void writeStructuralConflict(StructuralConflict structuralConflict) {
         String leftSource = getOriginalSource(structuralConflict.left);
         String rightSource = getOriginalSource(structuralConflict.right);
+        writeConflict(leftSource, rightSource);
+    }
 
+    private void writeConflict(String left, String right) {
         PrinterHelper helper = getPrinterTokenWriter().getPrinterHelper();
         int tabBefore = helper.getTabCount();
         helper.setTabCount(0);
 
         helper.writeln();
         writeConflictMarker(START_CONFLICT);
-        writelnNonEmpty(leftSource);
+        writelnNonEmpty(left);
         writeConflictMarker(MID_CONFLICT);
-        writelnNonEmpty(rightSource);
+        writelnNonEmpty(right);
         writeConflictMarker(END_CONFLICT);
 
         helper.setTabCount(tabBefore);
+    }
+
+    private PrinterHelper writeAtLeftMargin(String s) {
+        PrinterHelper helper = getPrinterTokenWriter().getPrinterHelper();
+        int tabBefore = helper.getTabCount();
+        helper.setTabCount(0);
+        helper.write(s);
+        return helper.setTabCount(tabBefore);
     }
 
     private void writeConflictMarker(String conflictMarker) {
@@ -93,10 +128,28 @@ public class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
         if (nodes.isEmpty())
             return "";
 
-        SourcePosition firstElemPos = nodes.get(0).getPosition();
-        SourcePosition lastElemPos = nodes.get(nodes.size() - 1).getPosition();
-        try (RandomAccessFile file = new RandomAccessFile(firstElemPos.getFile(), "r")) {
-            return getOriginalSource(firstElemPos, lastElemPos, file);
+        SourcePosition firstElemPos = getSourcePos(nodes.get(0));
+        SourcePosition lastElemPos = getSourcePos(nodes.get(nodes.size() - 1));
+        return getOriginalSource(firstElemPos, lastElemPos);
+    }
+
+    /**
+     * Get the source file position from a CtElement, taking care that Spork sometimes stores position information as
+     * metadata to circumvent the pretty-printers reliance on positional information (e.g. when printing comments).
+     */
+    private static SourcePosition getSourcePos(CtElement elem) {
+        SourcePosition pos = (SourcePosition) elem.getMetadata("position");
+        if (pos == null) {
+            pos = elem.getPosition();
+        }
+        assert pos != null && pos != SourcePosition.NOPOSITION;
+
+        return pos;
+    }
+
+    private static String getOriginalSource(SourcePosition start, SourcePosition end) {
+        try (RandomAccessFile file = new RandomAccessFile(start.getFile(), "r")) {
+            return getOriginalSource(start, end, file);
         } catch (IOException e) {
             e.printStackTrace();
             throw new RuntimeException("failed to read original source fragments");

--- a/src/main/java/se/kth/spork/spoon/ContentConflict.java
+++ b/src/main/java/se/kth/spork/spoon/ContentConflict.java
@@ -8,11 +8,11 @@ public class ContentConflict {
     public static final String METADATA_KEY = "SPORK_CONTENT_CONFLICT";
 
     private final CtRole role;
-    private final Optional<Object> base;
-    private final Object left;
-    private final Object right;
+    private final Optional<RoledValue> base;
+    private final RoledValue left;
+    private final RoledValue right;
 
-    public ContentConflict(CtRole role, Optional<Object> base, Object left, Object right) {
+    public ContentConflict(CtRole role, Optional<RoledValue> base, RoledValue left, RoledValue right) {
         this.role = role;
         this.base = base;
         this.left = left;
@@ -23,15 +23,15 @@ public class ContentConflict {
         return role;
     }
 
-    public Optional<Object> getBase() {
+    public Optional<RoledValue> getBase() {
         return base;
     }
 
-    public Object getLeft() {
+    public RoledValue getLeft() {
         return left;
     }
 
-    public Object getRight() {
+    public RoledValue getRight() {
         return right;
     }
 }

--- a/src/main/java/se/kth/spork/spoon/PcsInterpreter.java
+++ b/src/main/java/se/kth/spork/spoon/PcsInterpreter.java
@@ -286,7 +286,7 @@ public class PcsInterpreter {
             CtElement mergeParent = nodes.get(parent).getElement();
             CtElement dummy = (left.size() > 0 ? left.get(0) : right.get(0)).getElement();
 
-            dummy.putMetadata(StructuralConflict.STRUCTURAL_CONFLICT_METADATA_KEY, new StructuralConflict(
+            dummy.putMetadata(StructuralConflict.METADATA_KEY, new StructuralConflict(
                     left.stream().map(SpoonNode::getElement).collect(Collectors.toList()),
                     right.stream().map(SpoonNode::getElement).collect(Collectors.toList())));
             SpoonNode dummyNode = NodeFactory.wrap(dummy);
@@ -431,15 +431,13 @@ public class PcsInterpreter {
             } else {
                 RoledValues rvs = nodeContents.iterator().next().getValue();
 
-                for (Pair<CtRole, Object> roledValue : rvs) {
-                    mergeTree.setValueByRole(roledValue.first, roledValue.second);
+                for (RoledValue roledValue : rvs) {
+                    mergeTree.setValueByRole(roledValue.getRole(), roledValue.getValue());
                 }
             }
         }
 
     }
-
-
 
     /**
      * Create a shallow copy of a tree.

--- a/src/main/java/se/kth/spork/spoon/RoledValue.java
+++ b/src/main/java/se/kth/spork/spoon/RoledValue.java
@@ -1,0 +1,53 @@
+package se.kth.spork.spoon;
+
+import spoon.reflect.path.CtRole;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class RoledValue {
+    private final CtRole role;
+    private final Object value;
+    private final Map<Key, Object> metadata;
+
+    public enum Key {
+        RAW_CONTENT
+    }
+
+    public RoledValue(CtRole role, Object value) {
+        this.role = role;
+        this.value = value;
+        metadata = new HashMap<>();
+    }
+
+    public CtRole getRole() {
+        return role;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void putMetadata(Key key, Object value) {
+        metadata.put(key, value);
+    }
+
+    public Object getMetadata(Key key) {
+        return metadata.get(key);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RoledValue that = (RoledValue) o;
+        return role == that.role &&
+                Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(role, value);
+    }
+}

--- a/src/main/java/se/kth/spork/spoon/RoledValues.java
+++ b/src/main/java/se/kth/spork/spoon/RoledValues.java
@@ -11,21 +11,21 @@ import java.util.*;
  *
  * @author Simon Larsén
  */
-class RoledValues extends ArrayList<Pair<CtRole, Object>> {
+class RoledValues extends ArrayList<RoledValue> {
 
     public RoledValues() {
         super();
     }
 
-    public RoledValues(Collection<? extends Pair<CtRole, Object>> collection) {
+    public RoledValues(Collection<? extends RoledValue> collection) {
         super(collection);
     }
 
     public void add(CtRole role, Object value) {
-        add(new Pair<>(role, value));
+        add(new RoledValue(role, value));
     }
 
-    public Pair<CtRole, Object> set(int i, CtRole role, Object value) {
-        return set(i, new Pair<>(role, value));
+    public RoledValue set(int i, CtRole role, Object value) {
+        return set(i, new RoledValue(role, value));
     }
 }

--- a/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
+++ b/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.kth.spork.base3dm.*;
 import se.kth.spork.cli.SporkPrettyPrinter;
-import se.kth.spork.util.Pair;
 import se.kth.spork.util.Triple;
 import spoon.reflect.code.*;
 import spoon.reflect.cu.SourcePosition;
@@ -183,9 +182,18 @@ public class Spoon3dmMerge {
                 rvs.add(CtRole.IS_UPPER, elem.getValueByRole(CtRole.IS_UPPER));
             }
             if (elem instanceof CtComment) {
-                elem.setValueByRole(CtRole.POSITION, SourcePosition.NOPOSITION);
+                String rawContent = ((CtComment) elem).getRawContent();
+                RoledValue content = new RoledValue(CtRole.COMMENT_CONTENT, elem.getValueByRole(CtRole.COMMENT_CONTENT));
+                content.putMetadata(RoledValue.Key.RAW_CONTENT, rawContent);
+
+                rvs.add(content);
                 rvs.add(CtRole.COMMENT_TYPE, elem.getValueByRole(CtRole.COMMENT_TYPE));
-                rvs.add(CtRole.COMMENT_CONTENT, elem.getValueByRole(CtRole.COMMENT_CONTENT));
+
+                // due to comments relying on the position in the file ElementPrinterHelper.getComments, the position must be
+                // stored in metadata instead of in the actual comment. Otherwise, the mixing and matching of
+                // sources will cause many comments not to be printed.
+                elem.putMetadata("position", elem.getPosition());
+                elem.setPosition(SourcePosition.NOPOSITION);
             }
 
             return rvs;
@@ -214,16 +222,16 @@ public class Spoon3dmMerge {
 
                 for (int i = 0; i < leftRoledValues.size(); i++) {
                     int finalI = i;
-                    Pair<CtRole, Object> leftPair = leftRoledValues.get(i);
-                    Pair<CtRole, Object> rightPair = rightRoledValues.get(i);
-                    assert leftPair.first == rightPair.first;
+                    RoledValue leftPair = leftRoledValues.get(i);
+                    RoledValue rightPair = rightRoledValues.get(i);
+                    assert leftPair.getRole() == rightPair.getRole();
 
                     Optional<Object> baseValOpt = baseOpt.map(Content::getValue).map(rv -> rv.get(finalI))
-                            .map(p -> p.second);
+                            .map(RoledValue::getValue);
 
-                    CtRole role = leftPair.first;
-                    Object leftVal = leftPair.second;
-                    Object rightVal = rightPair.second;
+                    CtRole role = leftPair.getRole();
+                    Object leftVal = leftPair.getValue();
+                    Object rightVal = rightPair.getValue();
 
                     if (leftPair.equals(rightPair)) {
                         // this pair cannot possibly conflict
@@ -232,9 +240,11 @@ public class Spoon3dmMerge {
 
                     // left and right pairs differ and are so conflicting
                     // we add them as a conflict, but will later remove it if the conflict can be resolved
-                    unresolvedConflicts.push(
-                            new ContentConflict(role, baseValOpt, leftVal, rightVal)
-                    );
+                    unresolvedConflicts.push(new ContentConflict(
+                                    role,
+                                    baseOpt.map(Content::getValue).map(rv -> rv.get(finalI)),
+                                    leftPair,
+                                    rightPair));
 
 
                     Optional<?> merged = Optional.empty();

--- a/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
+++ b/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
@@ -10,10 +10,8 @@ import se.kth.spork.base3dm.*;
 import se.kth.spork.cli.SporkPrettyPrinter;
 import se.kth.spork.util.Pair;
 import se.kth.spork.util.Triple;
-import spoon.reflect.code.CtBinaryOperator;
-import spoon.reflect.code.CtLiteral;
-import spoon.reflect.code.CtOperatorAssignment;
-import spoon.reflect.code.CtUnaryOperator;
+import spoon.reflect.code.*;
+import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.*;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtReference;
@@ -180,13 +178,18 @@ public class Spoon3dmMerge {
 
             if (elem instanceof CtModifiable) {
                 rvs.add(CtRole.MODIFIER, elem.getValueByRole(CtRole.MODIFIER));
-            } else if (elem instanceof CtWildcardReference) {
+            }
+            if (elem instanceof CtWildcardReference) {
                 rvs.add(CtRole.IS_UPPER, elem.getValueByRole(CtRole.IS_UPPER));
+            }
+            if (elem instanceof CtComment) {
+                elem.setValueByRole(CtRole.POSITION, SourcePosition.NOPOSITION);
+                rvs.add(CtRole.COMMENT_TYPE, elem.getValueByRole(CtRole.COMMENT_TYPE));
+                rvs.add(CtRole.COMMENT_CONTENT, elem.getValueByRole(CtRole.COMMENT_CONTENT));
             }
 
             return rvs;
         }
-
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/se/kth/spork/spoon/StructuralConflict.java
+++ b/src/main/java/se/kth/spork/spoon/StructuralConflict.java
@@ -6,12 +6,12 @@ import java.util.List;
 
 /**
  * A simple class that provides some information on a structural conflict. Meant to be put as metadata on a conflict
- * "dummy node" using {@link StructuralConflict#STRUCTURAL_CONFLICT_METADATA_KEY} as the key.
+ * "dummy node" using {@link StructuralConflict#METADATA_KEY} as the key.
  *
  * @author Simon Larsén
  */
 public class StructuralConflict {
-    public static final String STRUCTURAL_CONFLICT_METADATA_KEY = "SPORK_STRUCTURAL_CONFLICT";
+    public static final String METADATA_KEY = "SPORK_STRUCTURAL_CONFLICT";
     public final List<CtElement> left;
     public final List<CtElement> right;
 

--- a/src/main/java/se/kth/spork/util/LineBasedMerge.java
+++ b/src/main/java/se/kth/spork/util/LineBasedMerge.java
@@ -1,0 +1,89 @@
+package se.kth.spork.util;
+
+import se.kth.spork.cli.SporkPrettyPrinter;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jgit.diff.RawText;
+import org.eclipse.jgit.diff.SequenceComparator;
+import org.eclipse.jgit.merge.MergeAlgorithm;
+import org.eclipse.jgit.merge.MergeChunk;
+import org.eclipse.jgit.merge.MergeResult;
+
+/**
+ * Line-based merge implementation using JGit.
+ *
+ * @author Simon Larsén
+ */
+public class LineBasedMerge {
+
+    /**
+     * Merge three revisions of a string using line-based merge.
+     *
+     * @param base The base revision.
+     * @param left The left revision.
+     * @param right The right revision.
+     * @return A line-based merge, with conflict markers in case of conflict.
+     */
+    public static String merge(String base, String left, String right) {
+        RawText baseRaw = new RawText(base.getBytes());
+        RawText leftRaw = new RawText(left.getBytes());
+        RawText rightRaw = new RawText(right.getBytes());
+
+        MergeAlgorithm merge = new MergeAlgorithm();
+        MergeResult<RawText> res = merge.merge(new SequenceComparator<RawText>() {
+            @Override
+            public boolean equals(RawText s, int i, RawText s1, int i1) {
+                return s.getString(i).equals(s1.getString(i));
+            }
+
+            @Override
+            public int hash(RawText s, int i) {
+                return Objects.hash(s.getString(i));
+            }
+        }, baseRaw, leftRaw, rightRaw);
+
+        Iterator<MergeChunk> it = res.iterator();
+        List<RawText> seqs = res.getSequences();
+        List<String> lines = new ArrayList<>();
+        boolean inConflict = false;
+
+        while (it.hasNext()) {
+            MergeChunk chunk = it.next();
+            RawText seq = seqs.get(chunk.getSequenceIndex());
+
+            if (chunk.getConflictState() == MergeChunk.ConflictState.FIRST_CONFLICTING_RANGE) {
+                inConflict = true;
+                lines.add(SporkPrettyPrinter.START_CONFLICT);
+            } else if (chunk.getConflictState() == MergeChunk.ConflictState.NEXT_CONFLICTING_RANGE) {
+                if (!inConflict) {
+                    lines.add(SporkPrettyPrinter.START_CONFLICT);
+                    inConflict = true;
+                }
+
+                lines.add(SporkPrettyPrinter.MID_CONFLICT);
+            }
+
+
+            for (int i = chunk.getBegin(); i < chunk.getEnd(); i++) {
+                lines.add(seq.getString(i));
+            }
+
+            if (chunk.getConflictState() == MergeChunk.ConflictState.NEXT_CONFLICTING_RANGE) {
+                lines.add(SporkPrettyPrinter.END_CONFLICT);
+                inConflict = false;
+            }
+
+        }
+
+        if (inConflict) {
+            lines.add(SporkPrettyPrinter.MID_CONFLICT);
+            lines.add(SporkPrettyPrinter.END_CONFLICT);
+        }
+
+        return String.join("\n", lines);
+    }
+}

--- a/src/test/java/se/kth/spork/cli/CliTest.java
+++ b/src/test/java/se/kth/spork/cli/CliTest.java
@@ -50,6 +50,8 @@ class CliTest {
 
         List<Util.Conflict> actualConflicts = Util.parseConflicts(prettyPrint);
 
+        System.out.println(prettyPrint);
+
         assertEquals(expectedConflicts, actualConflicts);
     }
 

--- a/src/test/resources/clean/both_modified/edit_different_comments/Base.java
+++ b/src/test/resources/clean/both_modified/edit_different_comments/Base.java
@@ -1,0 +1,79 @@
+import java.util.EmptyStackException;
+
+/**
+ * An array-based implementation of the Stack interface.
+ *
+ * @author Simon Larsén
+ */
+public class ArrayStack<T> implements Stack<T> {
+    private static final int INITIAL_CAPACITY = 10;
+    private Object[] elements;
+    private int size;
+
+    /**
+     * Creat an empty ArrayStack.
+     */
+    public ArrayStack() {
+        elements = new Object[INITIAL_CAPACITY];
+    }
+
+    @Override
+    public void push(T element) {
+        ensureCapacity(size + 1);
+        elements[size++] = element;
+    }
+
+    @Override
+    public T pop() {
+        T elem = checkedTop();
+        // null element to avoid blocking GC
+        elements[size--] = null;
+        return elem;
+    }
+
+    @Override
+    public T top() {
+        return checkedTop();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Checked fetching of the top element, throws an EmptyStackException if
+     * the stack is empty.
+     */
+    private T checkedTop() {
+        if (size == 0) {
+            throw new EmptyStackException();
+        }
+
+        return (T) elements[size - 1];
+    }
+
+    /**
+     * Ensure that the capacity is at least minCapacity.
+     */
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > elements.length) {
+            grow();
+        }
+    }
+
+    /**
+     * Replace the current backing array with a larger one and copy over the
+     * elements to the now array.
+     */
+    private void grow() {
+        Object[] newElements = new Object[elements.length << 1];
+        System.arraycopy(elements, 0, newElements, 0, elements.length);
+        elements = newElements;
+    }
+}

--- a/src/test/resources/clean/both_modified/edit_different_comments/Expected.java
+++ b/src/test/resources/clean/both_modified/edit_different_comments/Expected.java
@@ -1,0 +1,87 @@
+import java.util.EmptyStackException;
+
+/**
+ * An array-based implementation of the Stack interface.
+ *
+ * It's pretty neat.
+ *
+ * @author Simon Larsén
+ */
+public class ArrayStack<T> implements Stack<T> {
+    private static final int INITIAL_CAPACITY = 10;
+    private Object[] elements;
+    private int size;
+
+    /**
+     * Creat an empty ArrayStack.
+     */
+    public ArrayStack() {
+        elements = new Object[INITIAL_CAPACITY];
+    }
+
+    @Override
+    public void push(T element) {
+        ensureCapacity(size + 1);
+        elements[size++] = element;
+    }
+
+    @Override
+    public T pop() {
+        T elem = checkedTop();
+        // null element to avoid blocking garbage collection
+        elements[size--] = null;
+        return elem;
+    }
+
+    @Override
+    public T top() {
+        return checkedTop();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Checked fetching of the top element, throws an EmptyStackException if
+     * the stack is empty.
+     *
+     * @return The top element.
+     * @throws EmptyStackException if the stack is empty
+     */
+    private T checkedTop() {
+        if (size == 0) {
+            throw new EmptyStackException();
+        }
+
+        return (T) elements[size - 1];
+    }
+
+    /**
+     * Ensure that the capacity is at least minCapacity.
+     */
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > elements.length) {
+            grow();
+        }
+    }
+
+    /**
+     * Replace the current backing array with a larger one and copy over the
+     * elements to the now array.
+     *
+     * Time complexity: O(n)
+     */
+    private void grow() {
+        Object[] newElements = new Object[elements.length << 1];
+        // fastest way to copy an array
+        System.arraycopy(elements, 0, newElements, 0, elements.length);
+        elements = newElements;
+    }
+}

--- a/src/test/resources/clean/both_modified/edit_different_comments/Left.java
+++ b/src/test/resources/clean/both_modified/edit_different_comments/Left.java
@@ -1,0 +1,84 @@
+import java.util.EmptyStackException;
+
+/**
+ * An array-based implementation of the Stack interface.
+ *
+ * It's pretty neat.
+ *
+ * @author Simon Larsén
+ */
+public class ArrayStack<T> implements Stack<T> {
+    private static final int INITIAL_CAPACITY = 10;
+    private Object[] elements;
+    private int size;
+
+    /**
+     * Creat an empty ArrayStack.
+     */
+    public ArrayStack() {
+        elements = new Object[INITIAL_CAPACITY];
+    }
+
+    @Override
+    public void push(T element) {
+        ensureCapacity(size + 1);
+        elements[size++] = element;
+    }
+
+    @Override
+    public T pop() {
+        T elem = checkedTop();
+        // null element to avoid blocking GC
+        elements[size--] = null;
+        return elem;
+    }
+
+    @Override
+    public T top() {
+        return checkedTop();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Checked fetching of the top element, throws an EmptyStackException if
+     * the stack is empty.
+     */
+    private T checkedTop() {
+        if (size == 0) {
+            throw new EmptyStackException();
+        }
+
+        return (T) elements[size - 1];
+    }
+
+    /**
+     * Ensure that the capacity is at least minCapacity.
+     */
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > elements.length) {
+            grow();
+        }
+    }
+
+    /**
+     * Replace the current backing array with a larger one and copy over the
+     * elements to the now array.
+     *
+     * Time complexity: O(n)
+     */
+    private void grow() {
+        Object[] newElements = new Object[elements.length << 1];
+        // fastest way to copy an array
+        System.arraycopy(elements, 0, newElements, 0, elements.length);
+        elements = newElements;
+    }
+}

--- a/src/test/resources/clean/both_modified/edit_different_comments/Right.java
+++ b/src/test/resources/clean/both_modified/edit_different_comments/Right.java
@@ -1,0 +1,82 @@
+import java.util.EmptyStackException;
+
+/**
+ * An array-based implementation of the Stack interface.
+ *
+ * @author Simon Larsén
+ */
+public class ArrayStack<T> implements Stack<T> {
+    private static final int INITIAL_CAPACITY = 10;
+    private Object[] elements;
+    private int size;
+
+    /**
+     * Creat an empty ArrayStack.
+     */
+    public ArrayStack() {
+        elements = new Object[INITIAL_CAPACITY];
+    }
+
+    @Override
+    public void push(T element) {
+        ensureCapacity(size + 1);
+        elements[size++] = element;
+    }
+
+    @Override
+    public T pop() {
+        T elem = checkedTop();
+        // null element to avoid blocking garbage collection
+        elements[size--] = null;
+        return elem;
+    }
+
+    @Override
+    public T top() {
+        return checkedTop();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Checked fetching of the top element, throws an EmptyStackException if
+     * the stack is empty.
+     *
+     * @return The top element.
+     * @throws EmptyStackException if the stack is empty
+     */
+    private T checkedTop() {
+        if (size == 0) {
+            throw new EmptyStackException();
+        }
+
+        return (T) elements[size - 1];
+    }
+
+    /**
+     * Ensure that the capacity is at least minCapacity.
+     */
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > elements.length) {
+            grow();
+        }
+    }
+
+    /**
+     * Replace the current backing array with a larger one and copy over the
+     * elements to the now array.
+     */
+    private void grow() {
+        Object[] newElements = new Object[elements.length << 1];
+        System.arraycopy(elements, 0, newElements, 0, elements.length);
+        elements = newElements;
+    }
+}

--- a/src/test/resources/clean/left_modified/add_block_comment/Base.java
+++ b/src/test/resources/clean/left_modified/add_block_comment/Base.java
@@ -1,0 +1,5 @@
+class Cls {
+    public int add(int a, int b) {
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/add_block_comment/Expected.java
+++ b/src/test/resources/clean/left_modified/add_block_comment/Expected.java
@@ -1,0 +1,9 @@
+class Cls {
+    public int add(int a, int b) {
+        /*
+        this doesn't work, because c is not defined
+        return a + c;
+         */
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/add_block_comment/Left.java
+++ b/src/test/resources/clean/left_modified/add_block_comment/Left.java
@@ -1,0 +1,9 @@
+class Cls {
+    public int add(int a, int b) {
+        /*
+        this doesn't work, because c is not defined
+        return a + c;
+         */
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/add_block_comment/Right.java
+++ b/src/test/resources/clean/left_modified/add_block_comment/Right.java
@@ -1,0 +1,5 @@
+class Cls {
+    public int add(int a, int b) {
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/add_inline_comment/Base.java
+++ b/src/test/resources/clean/left_modified/add_inline_comment/Base.java
@@ -1,0 +1,5 @@
+class Cls {
+    public int add(int a, int b) {
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/add_inline_comment/Expected.java
+++ b/src/test/resources/clean/left_modified/add_inline_comment/Expected.java
@@ -1,0 +1,6 @@
+class Cls {
+    public int add(int a, int b) {
+        // add a and b
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/add_inline_comment/Left.java
+++ b/src/test/resources/clean/left_modified/add_inline_comment/Left.java
@@ -1,0 +1,6 @@
+class Cls {
+    public int add(int a, int b) {
+        // add a and b
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/add_inline_comment/Right.java
+++ b/src/test/resources/clean/left_modified/add_inline_comment/Right.java
@@ -1,0 +1,5 @@
+class Cls {
+    public int add(int a, int b) {
+        return a + b;
+    }
+}

--- a/src/test/resources/conflict/conflicting_comment_edits/Base.java
+++ b/src/test/resources/conflict/conflicting_comment_edits/Base.java
@@ -1,0 +1,79 @@
+import java.util.EmptyStackException;
+
+/**
+ * An array-based implementation of the Stack interface.
+ *
+ * @author Simon Larsén
+ */
+public class ArrayStack<T> implements Stack<T> {
+    private static final int INITIAL_CAPACITY = 10;
+    private Object[] elements;
+    private int size;
+
+    /**
+     * Creat an empty ArrayStack.
+     */
+    public ArrayStack() {
+        elements = new Object[INITIAL_CAPACITY];
+    }
+
+    @Override
+    public void push(T element) {
+        ensureCapacity(size + 1);
+        elements[size++] = element;
+    }
+
+    @Override
+    public T pop() {
+        T elem = checkedTop();
+        // null element to avoid blocking GC
+        elements[size--] = null;
+        return elem;
+    }
+
+    @Override
+    public T top() {
+        return checkedTop();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Checked fetching of the top element, throws an EmptyStackException if
+     * the stack is empty.
+     */
+    private T checkedTop() {
+        if (size == 0) {
+            throw new EmptyStackException();
+        }
+
+        return (T) elements[size - 1];
+    }
+
+    /**
+     * Ensure that the capacity is at least minCapacity.
+     */
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > elements.length) {
+            grow();
+        }
+    }
+
+    /**
+     * Replace the current backing array with a larger one and copy over the
+     * elements to the now array.
+     */
+    private void grow() {
+        Object[] newElements = new Object[elements.length << 1];
+        System.arraycopy(elements, 0, newElements, 0, elements.length);
+        elements = newElements;
+    }
+}

--- a/src/test/resources/conflict/conflicting_comment_edits/Expected.java
+++ b/src/test/resources/conflict/conflicting_comment_edits/Expected.java
@@ -1,0 +1,87 @@
+import java.util.EmptyStackException;
+
+/**
+ * An array-based implementation of the Stack interface.
+ *
+ * @author Simon Larsén
+ */
+public class ArrayStack<T> implements Stack<T> {
+    private static final int INITIAL_CAPACITY = 10;
+    private Object[] elements;
+    private int size;
+
+    /**
+<<<<<<< LEFT
+     * Create an empty ArrayStack.
+=======
+     * Creat an empty ArrayStack with an initial capacity of 10.
+>>>>>>> RIGHT
+     */
+    public ArrayStack() {
+        elements = new Object[INITIAL_CAPACITY];
+    }
+
+    @Override
+    public void push(T element) {
+        ensureCapacity(size + 1);
+        elements[size++] = element;
+    }
+
+    @Override
+    public T pop() {
+        T elem = checkedTop();
+<<<<<<< LEFT
+        // null element to avoid blocking garbage collector
+=======
+        // null element to avoid blocking the garbage collector
+>>>>>>> RIGHT
+        elements[size--] = null;
+        return elem;
+    }
+
+    @Override
+    public T top() {
+        return checkedTop();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Checked fetching of the top element, throws an EmptyStackException if
+     * the stack is empty.
+     */
+    private T checkedTop() {
+        if (size == 0) {
+            throw new EmptyStackException();
+        }
+
+        return (T) elements[size - 1];
+    }
+
+    /**
+     * Ensure that the capacity is at least minCapacity.
+     */
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > elements.length) {
+            grow();
+        }
+    }
+
+    /**
+     * Replace the current backing array with a larger one and copy over the
+     * elements to the now array.
+     */
+    private void grow() {
+        Object[] newElements = new Object[elements.length << 1];
+        System.arraycopy(elements, 0, newElements, 0, elements.length);
+        elements = newElements;
+    }
+}

--- a/src/test/resources/conflict/conflicting_comment_edits/Left.java
+++ b/src/test/resources/conflict/conflicting_comment_edits/Left.java
@@ -1,0 +1,79 @@
+import java.util.EmptyStackException;
+
+/**
+ * An array-based implementation of the Stack interface.
+ *
+ * @author Simon Larsén
+ */
+public class ArrayStack<T> implements Stack<T> {
+    private static final int INITIAL_CAPACITY = 10;
+    private Object[] elements;
+    private int size;
+
+    /**
+     * Create an empty ArrayStack.
+     */
+    public ArrayStack() {
+        elements = new Object[INITIAL_CAPACITY];
+    }
+
+    @Override
+    public void push(T element) {
+        ensureCapacity(size + 1);
+        elements[size++] = element;
+    }
+
+    @Override
+    public T pop() {
+        T elem = checkedTop();
+        // null element to avoid blocking garbage collector
+        elements[size--] = null;
+        return elem;
+    }
+
+    @Override
+    public T top() {
+        return checkedTop();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Checked fetching of the top element, throws an EmptyStackException if
+     * the stack is empty.
+     */
+    private T checkedTop() {
+        if (size == 0) {
+            throw new EmptyStackException();
+        }
+
+        return (T) elements[size - 1];
+    }
+
+    /**
+     * Ensure that the capacity is at least minCapacity.
+     */
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > elements.length) {
+            grow();
+        }
+    }
+
+    /**
+     * Replace the current backing array with a larger one and copy over the
+     * elements to the now array.
+     */
+    private void grow() {
+        Object[] newElements = new Object[elements.length << 1];
+        System.arraycopy(elements, 0, newElements, 0, elements.length);
+        elements = newElements;
+    }
+}

--- a/src/test/resources/conflict/conflicting_comment_edits/Right.java
+++ b/src/test/resources/conflict/conflicting_comment_edits/Right.java
@@ -1,0 +1,79 @@
+import java.util.EmptyStackException;
+
+/**
+ * An array-based implementation of the Stack interface.
+ *
+ * @author Simon Larsén
+ */
+public class ArrayStack<T> implements Stack<T> {
+    private static final int INITIAL_CAPACITY = 10;
+    private Object[] elements;
+    private int size;
+
+    /**
+     * Creat an empty ArrayStack with an initial capacity of 10.
+     */
+    public ArrayStack() {
+        elements = new Object[INITIAL_CAPACITY];
+    }
+
+    @Override
+    public void push(T element) {
+        ensureCapacity(size + 1);
+        elements[size++] = element;
+    }
+
+    @Override
+    public T pop() {
+        T elem = checkedTop();
+        // null element to avoid blocking the garbage collector
+        elements[size--] = null;
+        return elem;
+    }
+
+    @Override
+    public T top() {
+        return checkedTop();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Checked fetching of the top element, throws an EmptyStackException if
+     * the stack is empty.
+     */
+    private T checkedTop() {
+        if (size == 0) {
+            throw new EmptyStackException();
+        }
+
+        return (T) elements[size - 1];
+    }
+
+    /**
+     * Ensure that the capacity is at least minCapacity.
+     */
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > elements.length) {
+            grow();
+        }
+    }
+
+    /**
+     * Replace the current backing array with a larger one and copy over the
+     * elements to the now array.
+     */
+    private void grow() {
+        Object[] newElements = new Object[elements.length << 1];
+        System.arraycopy(elements, 0, newElements, 0, elements.length);
+        elements = newElements;
+    }
+}


### PR DESCRIPTION
Fix #35 

This PR adds handling for comments. Comments _are_ proper AST nodes, but they are printed together with the node they are associated with. When collected for printing, their relative position to the associated node is important, and when the comment comes from a different source file than the node it's attached to, that gets messed up. So, what happens here is that the positions of all comments is set to `NOPOSITION`. That should cause all comments to be printed above their associated node. That may cause some comments to spontaneously switch positions from below or inside the nod to above it, but that's significantly better than the comment not being printed at all.

Upon a content conflict in a comment, `JGit` is used to do a line-based merge.