### PR TITLE
Issue/61 pre process before print

### DIFF
--- a/src/main/java/se/kth/spork/cli/Cli.java
+++ b/src/main/java/se/kth/spork/cli/Cli.java
@@ -40,6 +40,9 @@ public class Cli {
      * @return A pretty-printed string representing the merged output.
      */
     public static String prettyPrint(CtModule spoonRoot) {
+        LOGGER.info("Pre-processing tree for pretty-printing");
+        new PrinterPreprocessor().scan(spoonRoot);
+
         CtPackage activePackage = spoonRoot.getRootPackage();
         while (!activePackage.getPackages().isEmpty()) {
             Set<CtPackage> subPkgs = activePackage.getPackages();

--- a/src/main/java/se/kth/spork/cli/PrinterPreprocessor.java
+++ b/src/main/java/se/kth/spork/cli/PrinterPreprocessor.java
@@ -1,0 +1,59 @@
+package se.kth.spork.cli;
+
+import se.kth.spork.spoon.ContentConflict;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.CtScanner;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A pre-processor that must run before pretty-printing a merged tree. It does things like embedding conflict values
+ * into literals and unsetting the source position of comments (so they get printed).
+ *
+ * @author Simon Larsén
+ */
+public class PrinterPreprocessor extends CtScanner {
+    public static final String RAW_COMMENT_CONFLICT = "spork_comment_conflict";
+
+    @Override
+    public void scan(CtElement element) {
+        if (element == null)
+            return;
+
+        @SuppressWarnings("unchecked")
+        List<ContentConflict> conflicts = (List<ContentConflict>) element.getMetadata(ContentConflict.METADATA_KEY);
+
+        if (conflicts != null) {
+            conflicts.forEach(conf -> processConflict(conf, element));
+        }
+
+        super.scan(element);
+    }
+
+    /**
+     * Process a conflict, and potentially mutate the element with the conflict. For example, values represented
+     * as strings may have the conflict embedded directly into the literal.
+     *
+     * @param conflict A content conflict.
+     * @param element The element associated with the conflict.
+     */
+    private void processConflict(ContentConflict conflict, CtElement element) {
+        Object leftVal = conflict.getLeft().getValue();
+        Object rightVal = conflict.getRight().getValue();
+
+        Optional<Object> processed = Optional.empty();
+
+        switch (conflict.getRole()) {
+            case NAME:
+            case VALUE:
+                // embed the conflict directly in the literal value
+                processed = Optional.of("\n" + SporkPrettyPrinter.START_CONFLICT + "\n"
+                        + leftVal + "\n" + SporkPrettyPrinter.MID_CONFLICT + "\n"
+                        + rightVal + "\n" + SporkPrettyPrinter.END_CONFLICT + "\n");
+                break;
+        }
+
+        processed.ifPresent(o -> element.setValueByRole(conflict.getRole(), o));
+    }
+}

--- a/src/main/java/se/kth/spork/cli/SporkPrettyPrinter.java
+++ b/src/main/java/se/kth/spork/cli/SporkPrettyPrinter.java
@@ -1,14 +1,10 @@
 package se.kth.spork.cli;
 
-import se.kth.spork.spoon.ContentConflict;
-import se.kth.spork.spoon.RoledValue;
 import se.kth.spork.spoon.StructuralConflict;
-import se.kth.spork.util.LineBasedMerge;
 import spoon.compiler.Environment;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.*;
 
 import java.io.IOException;
@@ -48,19 +44,9 @@ public class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
     @Override
     public void visitCtComment(CtComment comment) {
         @SuppressWarnings("unchecked")
-        List<ContentConflict> contentConflicts = (List<ContentConflict>) comment.getMetadata(
-                ContentConflict.METADATA_KEY);
-        if (contentConflicts != null) {
-            ContentConflict contents = contentConflicts.stream().filter(c -> c.getRole() == CtRole.COMMENT_CONTENT)
-                    .findFirst().get();
-
-            String rawLeft = (String) contents.getLeft().getMetadata(RoledValue.Key.RAW_CONTENT);
-            String rawRight = (String) contents.getRight().getMetadata(RoledValue.Key.RAW_CONTENT);
-            String rawBase = contents.getBase().isPresent() ?
-                    (String) contents.getBase().get().getMetadata(RoledValue.Key.RAW_CONTENT) : "";
-
-            String merged = LineBasedMerge.merge(rawBase, rawLeft, rawRight);
-            writeAtLeftMargin(merged);
+        Object rawConflict = comment.getMetadata(PrinterPreprocessor.RAW_COMMENT_CONFLICT_KEY);
+        if (rawConflict != null) {
+            writeAtLeftMargin(rawConflict.toString());
         } else {
             super.visitCtComment(comment);
         }
@@ -138,7 +124,7 @@ public class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
      * metadata to circumvent the pretty-printers reliance on positional information (e.g. when printing comments).
      */
     private static SourcePosition getSourcePos(CtElement elem) {
-        SourcePosition pos = (SourcePosition) elem.getMetadata("position");
+        SourcePosition pos = (SourcePosition) elem.getMetadata(PrinterPreprocessor.POSITION_KEY);
         if (pos == null) {
             pos = elem.getPosition();
         }

--- a/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
+++ b/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
@@ -7,7 +7,6 @@ import gumtree.spoon.builder.SpoonGumTreeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.kth.spork.base3dm.*;
-import se.kth.spork.cli.SporkPrettyPrinter;
 import se.kth.spork.util.Triple;
 import spoon.reflect.code.*;
 import spoon.reflect.cu.SourcePosition;
@@ -262,13 +261,6 @@ public class Spoon3dmMerge {
                                         baseValOpt.map(o -> (Set<ModifierKind>) o),
                                         (Set<ModifierKind>) leftVal,
                                         (Set<ModifierKind>) rightVal);
-                                break;
-                            case NAME:
-                            case VALUE:
-                                // FIXME This is not a merge, but a conflict embedding which should be done later, FIX
-                                merged = Optional.of(SporkPrettyPrinter.START_CONFLICT + "\n"
-                                        + leftVal + "\n" + SporkPrettyPrinter.MID_CONFLICT + "\n"
-                                        + rightVal + "\n" + SporkPrettyPrinter.END_CONFLICT);
                                 break;
                             default:
                                 // pass

--- a/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
+++ b/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import se.kth.spork.base3dm.*;
 import se.kth.spork.util.Triple;
 import spoon.reflect.code.*;
-import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.*;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtReference;
@@ -187,12 +186,6 @@ public class Spoon3dmMerge {
 
                 rvs.add(content);
                 rvs.add(CtRole.COMMENT_TYPE, elem.getValueByRole(CtRole.COMMENT_TYPE));
-
-                // due to comments relying on the position in the file ElementPrinterHelper.getComments, the position must be
-                // stored in metadata instead of in the actual comment. Otherwise, the mixing and matching of
-                // sources will cause many comments not to be printed.
-                elem.putMetadata("position", elem.getPosition());
-                elem.setPosition(SourcePosition.NOPOSITION);
             }
 
             return rvs;
@@ -208,8 +201,6 @@ public class Spoon3dmMerge {
             if (nodeContents.size() > 1) {
                 _ContentTriple revisions = getContentRevisions(nodeContents);
                 Optional<Content<SpoonNode, RoledValues>> baseOpt = revisions.first;
-                Content<SpoonNode, RoledValues> left = revisions.second;
-                Optional<RoledValues> baseRoledValues = baseOpt.map(Content::getValue);
                 RoledValues leftRoledValues = revisions.second.getValue();
                 RoledValues rightRoledValues = revisions.third.getValue();
 


### PR DESCRIPTION
Fix #61 

Introduces a preprocessor that runs before pretty-printing. This thing performs the various hacks required for the pretty-printing to look nice. Any further hacks for pretty-printing should go into the `PrinterPreprocessor`, and the `SporkPrettyPrinter` can then rely on them being there.