### PR TITLE
[fix] Only map nodes of the exact same type #57

### DIFF
--- a/src/main/java/se/kth/spork/spoon/SpoonMapping.java
+++ b/src/main/java/se/kth/spork/spoon/SpoonMapping.java
@@ -62,7 +62,10 @@ public class SpoonMapping {
                     throw new IllegalStateException("non-root node " + m.first.toShortString()
                             + " had no mapped Spoon object");
                 }
-            } else {
+            } else if (spoonSrc.getClass() == spoonDst.getClass()) {
+                // It is important to only map nodes of the exact same type, as 3DM has no notion of "correct"
+                // parent-child relationships. Mapping e.g. an array type reference to a non-array type reference
+                // may cause the resulting merge to try to treat either as the other, which does not work out.
                 mapping.put(spoonSrc, spoonDst);
             }
         }

--- a/src/test/resources/clean/left_modified/modify_array_type/Base.java
+++ b/src/test/resources/clean/left_modified/modify_array_type/Base.java
@@ -1,0 +1,3 @@
+class Cls {
+    private Integer[] arr;
+}

--- a/src/test/resources/clean/left_modified/modify_array_type/Expected.java
+++ b/src/test/resources/clean/left_modified/modify_array_type/Expected.java
@@ -1,0 +1,3 @@
+class Cls {
+    private Object arr;
+}

--- a/src/test/resources/clean/left_modified/modify_array_type/Left.java
+++ b/src/test/resources/clean/left_modified/modify_array_type/Left.java
@@ -1,0 +1,3 @@
+class Cls {
+    private Object arr;
+}

--- a/src/test/resources/clean/left_modified/modify_array_type/Right.java
+++ b/src/test/resources/clean/left_modified/modify_array_type/Right.java
@@ -1,0 +1,3 @@
+class Cls {
+    private Integer[] arr;
+}


### PR DESCRIPTION
Fix #57 

This PR fixes the problem of array type references and "normal" type references being matched, which in turn can result in crashes when the merge tree is being built. The reason for this behavior is that 3DM merge has absolutely no notion of correct relationships between parent and child nodes. Thus, if nodes of mismatched type are mapped, then their children may be merged such that whichever type comes out triumphant from the merge suddenly has children of types (or with roles) that it can't actually have. Thus, building the merged spoon tree crashes.

This is a very conservative fix, and forces matches to only be between exactly the same type of node. This may cause issues elsewhere. I'm not sure. Only benchmarks can tell. I do think it is necessary, however, due to 3DM's ignorance of valid and invalid parent-child relationships.