### PR TITLE
[feat] Allow root conflicts #87

### DIFF
--- a/src/main/java/se/kth/spork/spoon/MappingRemover.java
+++ b/src/main/java/se/kth/spork/spoon/MappingRemover.java
@@ -1,0 +1,48 @@
+package se.kth.spork.spoon;
+
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.CtScanner;
+
+/**
+ * Utility class for removing a node, along with all of its descendants, from a {@link SpoonMapping} instance.
+ *
+ * @author Simon Larsén
+ */
+class MappingRemover extends CtScanner {
+    private final SpoonMapping mapping;
+
+    /**
+     * Create a mapping remover for the provided mapping.
+     *
+     * @param mapping A mapping that this remover will operate on.
+     */
+    public MappingRemover(SpoonMapping mapping) {
+        this.mapping = mapping;
+    }
+
+    /**
+     * Remove this node and its associated virtual nodes from the mapping, and recursively remove all of its
+     * descendants in the same way.
+     *
+     * @param node A node to remove from the mapping.
+     */
+    public void removeRelatedMappings(SpoonNode node) {
+        CtElement elem = node.getElement();
+        scan(elem);
+    }
+
+    @Override
+    public void scan(CtElement element) {
+        if (element == null) {
+            return;
+        }
+
+        SpoonNode node = NodeFactory.wrap(element);
+
+        mapping.remove(node);
+        mapping.remove(NodeFactory.startOfChildList(node));
+        mapping.remove(NodeFactory.startOfChildList(node));
+
+        super.scan(element);
+    }
+}

--- a/src/main/java/se/kth/spork/spoon/SpoonMapping.java
+++ b/src/main/java/se/kth/spork/spoon/SpoonMapping.java
@@ -182,6 +182,13 @@ public class SpoonMapping {
         return getSrc(NodeFactory.wrap(dst)).getElement();
     }
 
+    public void remove(SpoonNode element) {
+        SpoonNode removedDst = srcs.remove(element);
+        SpoonNode removedSrc = dsts.remove(element);
+        dsts.remove(removedDst);
+        srcs.remove(removedSrc);
+    }
+
     public void put(CtElement src, CtElement dst) {
         put(NodeFactory.wrap(src), NodeFactory.wrap(dst));
     }

--- a/src/test/resources/clean/both_modified/root_conflict_with_edits_in_left/Base.java
+++ b/src/test/resources/clean/both_modified/root_conflict_with_edits_in_left/Base.java
@@ -1,0 +1,39 @@
+import java.util.Arrays;
+/**
+ * Implementation of the Sieve of Eratosthenes algorithm for checking if a
+ * number is prime or not. The implementation is lacking in error-checking
+ * and optimization, and needs some patching up!
+ *
+ * @author Simon Larsén
+ * @version 2017-08-05
+ */
+public class Sieve {
+
+    /**
+     * Check if a number is prime or not!
+     *
+     * Note that prime[n] denotes the primality of number n.
+     *
+     * @param   number  An integer value to be checked for primality.
+     * @return  true if number is prime, false otherwise.
+     */
+    public boolean isPrime(int number) {
+        boolean[] prime = new boolean[number + 1]; // + 1 because of 0-indexing
+        Arrays.fill(prime, true); // assume all numbers are prime
+        int sqrt = (int) Math.floor(Math.sqrt(number));
+        for (int i = 2; i <= sqrt; i++) {
+            if (prime[i]) {
+                for (int j = i*2; j < prime.length; j+=i) {
+                    prime[j] = false; // mark multiples of i as not prime
+                }
+            }
+        }
+
+        if (number <= 1) {
+            return false;
+        }
+
+
+        return prime[number];
+    }
+}

--- a/src/test/resources/clean/both_modified/root_conflict_with_edits_in_left/Expected.java
+++ b/src/test/resources/clean/both_modified/root_conflict_with_edits_in_left/Expected.java
@@ -1,0 +1,44 @@
+import java.util.Arrays;
+/**
+ * Implementation of the Sieve of Eratosthenes algorithm for checking if a
+ * number is prime or not. The implementation is lacking in error-checking
+ * and optimization, and needs some patching up!
+ *
+ * @author Simon Larsén
+ * @version 2017-08-05
+ */
+public class Sieve {
+
+    /**
+     * Check if a number is prime or not!
+     *
+     * Note that prime[n] denotes the primality of number n.
+     *
+     * @param   number  An integer value to be checked for primality.
+     * @return  true if number is prime, false otherwise.
+     */
+    public boolean isPrime(int number) {
+        if (number <= 1) {
+            System.out.println("Now it's in the right place!");
+            return false;
+        }
+
+        boolean[] prime = new boolean[number + 1]; // + 1 because of 0-indexing
+        Arrays.fill(prime, true); // assume all numbers are prime
+        int sqrt = (int) Math.floor(Math.sqrt(number));
+        for (int i = 2; i <= sqrt; i++) {
+
+            if (number <= 1) {
+                return false;
+            }
+
+            if (prime[i]) {
+                for (int j = i*2; j < prime.length; j+=i) {
+                    prime[j] = false; // mark multiples of i as not prime
+                }
+            }
+        }
+
+        return prime[number];
+    }
+}

--- a/src/test/resources/clean/both_modified/root_conflict_with_edits_in_left/Left.java
+++ b/src/test/resources/clean/both_modified/root_conflict_with_edits_in_left/Left.java
@@ -1,0 +1,39 @@
+import java.util.Arrays;
+/**
+ * Implementation of the Sieve of Eratosthenes algorithm for checking if a
+ * number is prime or not. The implementation is lacking in error-checking
+ * and optimization, and needs some patching up!
+ *
+ * @author Simon Larsén
+ * @version 2017-08-05
+ */
+public class Sieve {
+
+    /**
+     * Check if a number is prime or not!
+     *
+     * Note that prime[n] denotes the primality of number n.
+     *
+     * @param   number  An integer value to be checked for primality.
+     * @return  true if number is prime, false otherwise.
+     */
+    public boolean isPrime(int number) {
+        if (number <= 1) {
+            System.out.println("Now it's in the right place!");
+            return false;
+        }
+
+        boolean[] prime = new boolean[number + 1]; // + 1 because of 0-indexing
+        Arrays.fill(prime, true); // assume all numbers are prime
+        int sqrt = (int) Math.floor(Math.sqrt(number));
+        for (int i = 2; i <= sqrt; i++) {
+            if (prime[i]) {
+                for (int j = i*2; j < prime.length; j+=i) {
+                    prime[j] = false; // mark multiples of i as not prime
+                }
+            }
+        }
+
+        return prime[number];
+    }
+}

--- a/src/test/resources/clean/both_modified/root_conflict_with_edits_in_left/Right.java
+++ b/src/test/resources/clean/both_modified/root_conflict_with_edits_in_left/Right.java
@@ -1,0 +1,39 @@
+import java.util.Arrays;
+/**
+ * Implementation of the Sieve of Eratosthenes algorithm for checking if a
+ * number is prime or not. The implementation is lacking in error-checking
+ * and optimization, and needs some patching up!
+ *
+ * @author Simon Larsén
+ * @version 2017-08-05
+ */
+public class Sieve {
+
+    /**
+     * Check if a number is prime or not!
+     *
+     * Note that prime[n] denotes the primality of number n.
+     *
+     * @param   number  An integer value to be checked for primality.
+     * @return  true if number is prime, false otherwise.
+     */
+    public boolean isPrime(int number) {
+        boolean[] prime = new boolean[number + 1]; // + 1 because of 0-indexing
+        Arrays.fill(prime, true); // assume all numbers are prime
+        int sqrt = (int) Math.floor(Math.sqrt(number));
+        for (int i = 2; i <= sqrt; i++) {
+
+            if (number <= 1) {
+                return false;
+            }
+
+            if (prime[i]) {
+                for (int j = i*2; j < prime.length; j+=i) {
+                    prime[j] = false; // mark multiples of i as not prime
+                }
+            }
+        }
+
+        return prime[number];
+    }
+}

--- a/src/test/resources/clean/both_modified/simple_root_conflict/Base.java
+++ b/src/test/resources/clean/both_modified/simple_root_conflict/Base.java
@@ -1,0 +1,9 @@
+class Cls {
+    public static void main(String[] args) {
+        if (true) {
+        }
+        System.out.println("Hello");
+        if (true) {
+        }
+    }
+}

--- a/src/test/resources/clean/both_modified/simple_root_conflict/Expected.java
+++ b/src/test/resources/clean/both_modified/simple_root_conflict/Expected.java
@@ -1,0 +1,10 @@
+class Cls {
+    public static void main(String[] args) {
+        if (true) {
+            System.out.println("Hello");
+        }
+        if (true) {
+            System.out.println("Hello");
+        }
+    }
+}

--- a/src/test/resources/clean/both_modified/simple_root_conflict/Left.java
+++ b/src/test/resources/clean/both_modified/simple_root_conflict/Left.java
@@ -1,0 +1,9 @@
+class Cls {
+    public static void main(String[] args) {
+        if (true) {
+            System.out.println("Hello");
+        }
+        if (true) {
+        }
+    }
+}

--- a/src/test/resources/clean/both_modified/simple_root_conflict/Right.java
+++ b/src/test/resources/clean/both_modified/simple_root_conflict/Right.java
@@ -1,0 +1,9 @@
+class Cls {
+    public static void main(String[] args) {
+        if (true) {
+        }
+        if (true) {
+            System.out.println("Hello");
+        }
+    }
+}


### PR DESCRIPTION
Fix #87 

This PR allows root conflicts to occur. That is to say, nodes are allowed to be moved to different places. This is achieved by actually computing the merge, and if any node is found to be in a root conflict, it (along with its descendants and any associated virtual nodes, recursively) is removed from the tree mappings and then the merge is recomputed. As the nodes in root conflicts are no longer mapped, they can't possibly get into root conflicts: they are as far as 3DM knows unique nodes.

This has added benefits. For example, consider an `if` statement moved to two different places by left and right, and then a statement is inserted into e.g. left's version of the `if` statement. If we had allowed root conflicts in some way such that the moved nodes had still been mapped (but allowed to be duplicated in the tree), this modification would be inserted into both sites the node was moved to. That doesn't quite make sense. Now that the two moved nodes are unique, the added statement is only inserted in the proper location. See `root_conflict_with_edits_in_left` for an example: https://github.com/KTH/spork/pull/89/files

It's pretty inefficient, but as root conflicts are quite rare it probably doesn't matter much.

See the added test cases for some examples where this could happen.