### PR TITLE
[feat] Use original source for methods and fields

### DIFF
--- a/src/main/java/se/kth/spork/cli/Cli.java
+++ b/src/main/java/se/kth/spork/cli/Cli.java
@@ -11,7 +11,6 @@ import se.kth.spork.spoon.Spoon3dmMerge;
 import se.kth.spork.util.LineBasedMerge;
 import se.kth.spork.util.Pair;
 import spoon.reflect.declaration.*;
-import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,12 +59,9 @@ public class Cli {
             activePackage = pkgOpt.get();
         }
 
-        @SuppressWarnings("unchecked")
-        Collection<CtImport> imports = (Collection<CtImport>) spoonRoot.getMetadata(Parser.IMPORT_STATEMENTS);
-        List<String> importStrings = imports.stream()
-                .map(imp -> new DefaultJavaPrettyPrinter(spoonRoot.getFactory().getEnvironment())
-                        .scan(imp).toString()).collect(Collectors.toList());
-        List<String> importNames = importStrings.stream()
+        Collection<?> imports = (Collection<?>) spoonRoot.getMetadata(Parser.IMPORT_STATEMENTS);
+        List<String> importNames = imports.stream()
+                .map(Object::toString)
                 .map(impStmt -> impStmt.substring("import ".length(), impStmt.length() - 1))
                 .collect(Collectors.toList());
         new PrinterPreprocessor(importNames, activePackage.getQualifiedName()).scan(spoonRoot);
@@ -76,12 +72,12 @@ public class Cli {
             sb.append("package ").append(activePackage.getQualifiedName()).append(";").append("\n\n");
         }
 
-        importStrings.forEach(sb::append);
+        for (Object imp : imports) {
+            sb.append(imp).append("\n");
+        }
 
         for (CtType<?> type : activePackage.getTypes()) {
-            SporkPrettyPrinter sporkPrinter = new SporkPrettyPrinter(spoonRoot.getFactory().getEnvironment());
-            sporkPrinter.scan(type);
-            sb.append("\n\n").append(sporkPrinter.toString());
+            sb.append("\n\n").append(type);
         }
 
         return sb.toString();

--- a/src/main/java/se/kth/spork/cli/Cli.java
+++ b/src/main/java/se/kth/spork/cli/Cli.java
@@ -19,10 +19,12 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Command line interface for Spork.
@@ -117,22 +119,20 @@ public class Cli {
             leftModule = Parser.parse(prettyPrint(leftModule));
             rightModule = Parser.parse(prettyPrint(rightModule));
 
-            Set<?> leftImports = new HashSet<>((Collection<?>) leftModule.getMetadata(Parser.IMPORT_STATEMENTS));
-            Set<?> rightImports = new HashSet<>((Collection<?>) rightModule.getMetadata(Parser.IMPORT_STATEMENTS));
-            Set<?> intersection = new HashSet<>(leftImports);
-            intersection.retainAll(rightImports);
+            Object leftImports = leftModule.getMetadata(Parser.IMPORT_STATEMENTS);
+            Object rightImports = rightModule.getMetadata(Parser.IMPORT_STATEMENTS);
 
             Diff diff = new AstComparator().compare(leftModule, rightModule);
-
             System.out.println(diff);
 
-            long editCount = Stream.of(leftImports, rightImports)
-                    .flatMap(Set::stream).filter(e -> !intersection.contains(e)).count();
-            editCount += diff.getRootOperations().size();
+            boolean importsEqual = leftImports.equals(rightImports);
+            if (!importsEqual) {
+                LOGGER.warn("Import statements differ");
+                LOGGER.info("Left: " + leftImports);
+                LOGGER.info("Right: " + rightImports);
+            }
 
-            System.out.println(editCount);
-
-            return 0;
+            return diff.getRootOperations().isEmpty() && importsEqual ? 0 : 1;
         }
     }
 

--- a/src/main/java/se/kth/spork/cli/PrinterPreprocessor.java
+++ b/src/main/java/se/kth/spork/cli/PrinterPreprocessor.java
@@ -79,9 +79,10 @@ public class PrinterPreprocessor extends CtScanner {
      */
     private void handleIncorrectExplicitPackages(CtElement element) {
         if (element instanceof CtPackageReference) {
-            String pkgName = ((CtPackageReference) element).getQualifiedName();
+            CtPackageReference pkgRef = (CtPackageReference)  element;
+            String pkgName = pkgRef.getQualifiedName();
             CtElement parent = element.getParent();
-            if (pkgName.equals(activePackage)) {
+            if (pkgName.equals(activePackage) || pkgRef.getSimpleName().isEmpty()) {
                 element.setImplicit(true);
             } else if (parent instanceof CtTypeReference) {
                 String parentQualName = ((CtTypeReference<?>) parent).getQualifiedName();

--- a/src/main/java/se/kth/spork/cli/SourceExtractor.java
+++ b/src/main/java/se/kth/spork/cli/SourceExtractor.java
@@ -1,0 +1,146 @@
+package se.kth.spork.cli;
+
+import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.declaration.CtElement;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A class for extracting source code and related information from Spoon nodes.
+ *
+ * @author Simon Larsén
+ */
+public class SourceExtractor {
+
+    /**
+     * Get the original source fragment corresponding to the nodes provided, or an empty string if the list is
+     * empty. Note that the nodes must be adjacent in the source file, and in the same order as in the source.
+     *
+     * @param nodes A possibly empty list of adjacent nodes.
+     * @return The original source code fragment, including any leading indentation on the first line.
+     */
+    static String getOriginalSource(List<CtElement> nodes) {
+        if (nodes.isEmpty())
+            return "";
+
+        SourcePosition firstElemPos = getSourcePos(nodes.get(0));
+        SourcePosition lastElemPos = getSourcePos(nodes.get(nodes.size() - 1));
+        return getOriginalSource(firstElemPos, lastElemPos);
+    }
+
+    /**
+     * Get the original source code fragment associated with this element, including any leading indentation.
+     *
+     * @param elem A Spoon element.
+     * @return The original source code associated with the elemen.
+     */
+    static String getOriginalSource(CtElement elem) {
+        SourcePosition pos = getSourcePos(elem);
+        return getOriginalSource(pos, pos);
+    }
+
+    /**
+     * Return the indentation count for this element. This is a bit hit-and-miss, but it usually works. It finds
+     * the line that the element starts on, and counts the amount of indentation characters until the first character
+     * on the line.
+     *
+     * @param elem A Spoon element.
+     * @return The amount of indentation characters preceding the first non-indentation character on the line this
+     *      element is defined on.
+     */
+    static int getIndentation(CtElement elem) {
+        SourcePosition pos = getSourcePos(elem);
+        byte[] fileBytes = pos.getCompilationUnit().getOriginalSourceCode().getBytes(Charset.defaultCharset());
+        int count = 0;
+
+        int[] lineSepPositions = pos.getCompilationUnit().getLineSeparatorPositions();
+        int current = 0;
+        while (current < lineSepPositions.length && lineSepPositions[current] > pos.getSourceStart())
+            current++;
+
+
+        while (current + count < pos.getSourceStart()) {
+            byte b = fileBytes[current + count];
+            if (!isIndentation(b)) {
+                break;
+            }
+            ++count;
+        }
+        return count;
+    }
+
+    /**
+     * Get the source file position from a CtElement, taking care that Spork sometimes stores position information as
+     * metadata to circumvent the pretty-printers reliance on positional information (e.g. when printing comments).
+     */
+    private static SourcePosition getSourcePos(CtElement elem) {
+        SourcePosition pos = (SourcePosition) elem.getMetadata(PrinterPreprocessor.POSITION_KEY);
+        if (pos == null) {
+            pos = elem.getPosition();
+        }
+        assert pos != null && pos != SourcePosition.NOPOSITION;
+
+        return pos;
+    }
+
+    private static String getOriginalSource(SourcePosition start, SourcePosition end) {
+        byte[] source = start.getCompilationUnit().getOriginalSourceCode().getBytes(Charset.defaultCharset());
+        return getOriginalSource(start, end, source);
+    }
+
+    /**
+     * Get the original source code fragment starting at start and ending at end, including indentation if start is
+     * the first element on its source code line.
+     *
+     * @param start The source position of the first element.
+     * @param end   The source position of the last element.
+     * @return The source code fragment starting at start and ending at end, including leading indentation.
+     * @throws IOException
+     */
+    private static String getOriginalSource(SourcePosition start, SourcePosition end, byte[] source) {
+        int startByte = precededByIndentation(source, start) ?
+                getLineStartByte(start) : start.getSourceStart();
+        int endByte = end.getSourceEnd();
+
+        if (isIndentation(source[startByte])) {
+            startByte++;
+            endByte++;
+        }
+
+        byte[] content = Arrays.copyOfRange(source, startByte, endByte + 1);
+
+        return new String(content, Charset.defaultCharset());
+    }
+
+    private static boolean precededByIndentation(byte[] source, SourcePosition pos) {
+        int lineStartByte = getLineStartByte(pos);
+
+        for (int i = lineStartByte; i < pos.getSourceStart(); i++) {
+            if (!isIndentation(source[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int getLineStartByte(SourcePosition pos) {
+        if (pos.getLine() == 1)
+            return 0;
+
+        int sourceStart = pos.getSourceStart() - 1;
+
+        int[] lineSepPositions = pos.getCompilationUnit().getLineSeparatorPositions();
+        int current = 0;
+        while (lineSepPositions[current] > sourceStart)
+            current++;
+
+        return lineSepPositions[current];
+    }
+
+    private static boolean isIndentation(byte b) {
+        return b == ' ' || b == '\t';
+    }
+}

--- a/src/main/java/se/kth/spork/cli/SporkPrettyPrinter.java
+++ b/src/main/java/se/kth/spork/cli/SporkPrettyPrinter.java
@@ -5,25 +5,19 @@ import se.kth.spork.spoon.PcsInterpreter;
 import se.kth.spork.spoon.StructuralConflict;
 import se.kth.spork.util.Pair;
 import spoon.compiler.Environment;
-import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtComment;
-import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.DefaultTokenWriter;
 import spoon.reflect.visitor.PrinterHelper;
 import spoon.reflect.visitor.PrintingContext;
-import spoon.support.StandardEnvironment;
-import spoon.support.sniper.SniperJavaPrettyPrinter;
 
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.charset.Charset;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Optional;
 
 public final class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
     public static final String START_CONFLICT = "<<<<<<< LEFT";
@@ -71,13 +65,8 @@ public final class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
         } else if (e.getMetadata(PcsInterpreter.SINGLE_REVISION_KEY) != null &&
                 (e instanceof CtMethod || e instanceof CtField)) {
             CtElement originalElement = (CtElement) e.getMetadata(PcsInterpreter.ORIGINAL_NODE_KEY);
-            String sniped = getOriginalSource(originalElement);
-            /**
-            env.useTabulations(true); // required for sniper mode
-            String sniped = originalElement.toString();
-            env.useTabulations(false); // required for SporkPrettyPrinter
-             */
-            printerHelper.writeSniperContent(sniped, getTabCount(originalElement));
+            String originalSource = SourceExtractor.getOriginalSource(originalElement);
+            printerHelper.writeRawSourceCode(originalSource, SourceExtractor.getIndentation(originalElement));
             return this;
         }
 
@@ -116,132 +105,9 @@ public final class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
      * Write both pats of a structural conflict.
      */
     private void writeStructuralConflict(StructuralConflict structuralConflict) {
-        String leftSource = getOriginalSource(structuralConflict.left);
-        String rightSource = getOriginalSource(structuralConflict.right);
+        String leftSource = SourceExtractor.getOriginalSource(structuralConflict.left);
+        String rightSource = SourceExtractor.getOriginalSource(structuralConflict.right);
         printerHelper.writeConflict(leftSource, rightSource);
-    }
-
-    /**
-     * Write the provided string plus a line ending only if the string is non-empty.
-     */
-    private void writelnNonEmpty(String s) {
-        if (s.isEmpty())
-            return;
-
-        PrinterHelper helper = getPrinterTokenWriter().getPrinterHelper();
-
-        helper.write(s);
-        helper.writeln();
-    }
-
-    /**
-     * Get the original source fragment corresponding to the nodes provided, or an empty string if the list is
-     * empty. Note that the nodes must be adjacent in the source file, and in the same order as in the source.
-     *
-     * @param nodes A possibly empty list of adjacent nodes.
-     * @return The original source code fragment, including any leading indentation on the first line.
-     */
-    private static String getOriginalSource(List<CtElement> nodes) {
-        if (nodes.isEmpty())
-            return "";
-
-        SourcePosition firstElemPos = getSourcePos(nodes.get(0));
-        SourcePosition lastElemPos = getSourcePos(nodes.get(nodes.size() - 1));
-        return getOriginalSource(firstElemPos, lastElemPos);
-    }
-
-    private static String getOriginalSource(CtElement elem) {
-        SourcePosition pos = getSourcePos(elem);
-        return getOriginalSource(pos, pos);
-    }
-
-    /**
-     * Get the source file position from a CtElement, taking care that Spork sometimes stores position information as
-     * metadata to circumvent the pretty-printers reliance on positional information (e.g. when printing comments).
-     */
-    private static SourcePosition getSourcePos(CtElement elem) {
-        SourcePosition pos = (SourcePosition) elem.getMetadata(PrinterPreprocessor.POSITION_KEY);
-        if (pos == null) {
-            pos = elem.getPosition();
-        }
-        assert pos != null && pos != SourcePosition.NOPOSITION;
-
-        return pos;
-    }
-
-    private static String getOriginalSource(SourcePosition start, SourcePosition end) {
-        byte[] source = start.getCompilationUnit().getOriginalSourceCode().getBytes(Charset.defaultCharset());
-        return getOriginalSource(start, end, source);
-    }
-
-    /**
-     * Get the original source code fragment starting at start and ending at end, including indentation if start is
-     * the first element on its source code line.
-     *
-     * @param start            The source position of the first element.
-     * @param end              The source position of the last element.
-     * @return The source code fragment starting at start and ending at end, including leading indentation.
-     * @throws IOException
-     */
-    private static String getOriginalSource(SourcePosition start, SourcePosition end, byte[] source) {
-        int startByte = precededByIndentation(source, start) ?
-                getLineStartByte(start) : start.getSourceStart();
-        int endByte = end.getSourceEnd();
-
-        if (source[startByte] == 32) {
-            startByte++;
-            endByte++;
-        }
-
-        byte[] content = Arrays.copyOfRange(source, startByte, endByte + 1);
-
-        return new String(content, Charset.defaultCharset());
-    }
-
-    private static boolean precededByIndentation(byte[] source, SourcePosition pos) {
-        int lineStartByte = getLineStartByte(pos);
-
-        for (int i = lineStartByte; i < pos.getSourceStart(); i++) {
-            if (source[i] != 32) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static int getTabCount(CtElement elem) {
-        SourcePosition pos = getSourcePos(elem);
-        byte[] fileBytes = pos.getCompilationUnit().getOriginalSourceCode().getBytes(Charset.defaultCharset());
-        int count = 0;
-
-        int[] lineSepPositions = pos.getCompilationUnit().getLineSeparatorPositions();
-        int current = 0;
-        while (current < lineSepPositions.length && lineSepPositions[current] > pos.getSourceStart())
-            current++;
-
-
-        while (current + count < pos.getSourceStart()) {
-            byte b = fileBytes[current + count];
-            if (b != 32) {
-                break;
-            }
-            ++count;
-        }
-        return count;
-    }
-
-    private static int getLineStartByte(SourcePosition pos) {
-        if (pos.getLine() == 1)
-            return 0;
-
-        int sourceStart = pos.getSourceStart() - 1;
-
-        int[] lineSepPositions = pos.getCompilationUnit().getLineSeparatorPositions();
-        int current = 0;
-        while (lineSepPositions[current] > sourceStart)
-            current++;
-
-        return lineSepPositions[current];
     }
 
     private class SporkPrinterHelper extends PrinterHelper {
@@ -313,22 +179,26 @@ public final class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
             return this;
         }
 
-        public SporkPrinterHelper writeSniperContent(String s, int tabCount) {
+        /**
+         * Write raw source code, attempting to honor indentation.
+         */
+        public SporkPrinterHelper writeRawSourceCode(String s, int indentationCount) {
             String[] lines = s.split("\n");
             if (lines.length == 1) {
-                return write(s);
+                super.write(s);
+                return this;
             }
 
             write(lines[0]);
 
             int initialTabCount = getTabCount();
-            setTabCount(tabCount / 4);
+            setTabCount(indentationCount / env.getTabulationSize());
 
 
             for (int i = 1; i < lines.length; i++) {
                 writeln();
                 String line = lines[i];
-                write(trimIndentation(line, tabCount));
+                write(trimIndentation(line, indentationCount));
             }
             setTabCount(initialTabCount);
             return this;
@@ -336,26 +206,13 @@ public final class SporkPrettyPrinter extends DefaultJavaPrettyPrinter {
 
 
         private String trimIndentation(String s, int trimAmount) {
-            if (s.length() >= trimAmount && onlyWhitespace(s.substring(0, trimAmount))) {
+            if (s.length() >= trimAmount && isOnlyWhitespace(s.substring(0, trimAmount))) {
                 return s.substring(trimAmount);
             }
             return s;
         }
 
-        private int determineTabCount(String s) {
-            for (int i = 0; i < s.length(); i++) {
-                char c = s.charAt(i);
-                if (!Character.isWhitespace(c)) {
-                    if (c == '*') { // this is most likely a block comment, which has an extra indentation
-                        return i - 1;
-                    }
-                    return i;
-                }
-            }
-            return 0;
-        }
-
-        private boolean onlyWhitespace(String s) {
+        private boolean isOnlyWhitespace(String s) {
             for (char c : s.toCharArray()) {
                 if (!Character.isWhitespace(c))
                     return false;

--- a/src/main/java/se/kth/spork/spoon/ContentMerger.java
+++ b/src/main/java/se/kth/spork/spoon/ContentMerger.java
@@ -22,138 +22,124 @@ import java.util.stream.Stream;
  */
 public class ContentMerger {
 
-    /**
-     * Try to resolve content conflicts in the merge.
-     *
-     * @param delta A merged TStar.
-     * @return true if unresolvable conflicts were detected. This implies that a content conflict has been placed in
-     * the tree.
-     */
     @SuppressWarnings("unchecked")
-    static boolean handleContentConflicts(ChangeSet<SpoonNode, RoledValues> delta) {
+    static Pair<RoledValues, Boolean> mergedContent(SpoonNode node, Set<Content<SpoonNode, RoledValues>> nodeContents) {
         boolean hasConflict = false;
+        if (nodeContents.size() == 1) {
+            return Pair.of(nodeContents.iterator().next().getValue(), hasConflict);
+        }
 
-        for (Pcs<SpoonNode> pcs : delta.getPcsSet()) {
-            SpoonNode pred = pcs.getPredecessor();
-            Set<Content<SpoonNode, RoledValues>> nodeContents = delta.getContent(pred);
+        _ContentTriple revisions = getContentRevisions(nodeContents);
+        Optional<Content<SpoonNode, RoledValues>> baseOpt = revisions.first;
+        RoledValues leftRoledValues = revisions.second.getValue();
+        RoledValues rightRoledValues = revisions.third.getValue();
 
-            if (nodeContents.size() > 1) {
-                _ContentTriple revisions = getContentRevisions(nodeContents);
-                Optional<Content<SpoonNode, RoledValues>> baseOpt = revisions.first;
-                RoledValues leftRoledValues = revisions.second.getValue();
-                RoledValues rightRoledValues = revisions.third.getValue();
+        // NOTE: It is important that the left values are copied,
+        // by convention the LEFT values should be put into the tree whenever a conflict cannot be resolved
+        RoledValues mergedRoledValues = new RoledValues(leftRoledValues);
 
-                // NOTE: It is important that the left values are copied,
-                // by convention the LEFT values should be put into the tree whenever a conflict cannot be resolved
-                RoledValues mergedRoledValues = new RoledValues(leftRoledValues);
+        assert leftRoledValues.size() == rightRoledValues.size();
 
-                assert leftRoledValues.size() == rightRoledValues.size();
+        Deque<ContentConflict> unresolvedConflicts = new ArrayDeque<>();
 
-                Deque<ContentConflict> unresolvedConflicts = new ArrayDeque<>();
+        for (int i = 0; i < leftRoledValues.size(); i++) {
+            int finalI = i;
+            RoledValue leftPair = leftRoledValues.get(i);
+            RoledValue rightPair = rightRoledValues.get(i);
+            assert leftPair.getRole() == rightPair.getRole();
 
-                for (int i = 0; i < leftRoledValues.size(); i++) {
-                    int finalI = i;
-                    RoledValue leftPair = leftRoledValues.get(i);
-                    RoledValue rightPair = rightRoledValues.get(i);
-                    assert leftPair.getRole() == rightPair.getRole();
+            Optional<Object> baseValOpt = baseOpt.map(Content::getValue).map(rv -> rv.get(finalI))
+                    .map(RoledValue::getValue);
 
-                    Optional<Object> baseValOpt = baseOpt.map(Content::getValue).map(rv -> rv.get(finalI))
-                            .map(RoledValue::getValue);
+            CtRole role = leftPair.getRole();
+            Object leftVal = leftPair.getValue();
+            Object rightVal = rightPair.getValue();
 
-                    CtRole role = leftPair.getRole();
-                    Object leftVal = leftPair.getValue();
-                    Object rightVal = rightPair.getValue();
+            if (leftPair.equals(rightPair)) {
+                // this pair cannot possibly conflict
+                continue;
+            }
 
-                    if (leftPair.equals(rightPair)) {
-                        // this pair cannot possibly conflict
-                        continue;
-                    }
-
-                    // left and right pairs differ and are so conflicting
-                    // we add them as a conflict, but will later remove it if the conflict can be resolved
-                    unresolvedConflicts.push(new ContentConflict(
-                            role,
-                            baseOpt.map(Content::getValue).map(rv -> rv.get(finalI)),
-                            leftPair,
-                            rightPair));
+            // left and right pairs differ and are so conflicting
+            // we add them as a conflict, but will later remove it if the conflict can be resolved
+            unresolvedConflicts.push(new ContentConflict(
+                    role,
+                    baseOpt.map(Content::getValue).map(rv -> rv.get(finalI)),
+                    leftPair,
+                    rightPair));
 
 
-                    Optional<?> merged = Optional.empty();
+            Optional<?> merged = Optional.empty();
 
-                    // sometimes a value can be partially merged (e.g. modifiers), and then we want to be
-                    // able to set the merged value, AND flag a conflict.
-                    boolean conflictPresent = false;
+            // sometimes a value can be partially merged (e.g. modifiers), and then we want to be
+            // able to set the merged value, AND flag a conflict.
+            boolean conflictPresent = false;
 
-                    // if either value is equal to base, we keep THE OTHER one
-                    if (baseValOpt.isPresent() && baseValOpt.get().equals(leftVal)) {
-                        merged = Optional.of(rightVal);
-                    } else if (baseValOpt.isPresent() && baseValOpt.get().equals(rightVal)) {
-                        merged = Optional.of(leftVal);
-                    } else {
-                        // we need to actually work for this merge :(
-                        switch (role) {
-                            case IS_IMPLICIT:
-                                if (baseValOpt.isPresent()) {
-                                    merged = Optional.of(!(Boolean) baseValOpt.get());
-                                } else {
-                                    // when in doubt, discard implicitness
-                                    merged = Optional.of(false);
-                                }
-                                break;
-                            case MODIFIER:
-                                Pair<Boolean, Optional<Set<ModifierKind>>> mergePair = mergeModifierKinds(
-                                        baseValOpt.map(o -> (Set<ModifierKind>) o),
-                                        (Set<ModifierKind>) leftVal,
-                                        (Set<ModifierKind>) rightVal);
-                                conflictPresent = mergePair.first;
-                                merged = mergePair.second;
-                                break;
-                            case COMMENT_CONTENT:
-                                merged = mergeComments(baseValOpt.orElse(""), leftVal, rightVal);
-                                break;
-                            case IS_UPPER:
-                                merged = mergeIsUpper(
-                                        baseOpt.map(c -> c.getValue().getElement()),
-                                        leftRoledValues.getElement(),
-                                        rightRoledValues.getElement()
-                                );
-                                break;
-                            default:
-                                // pass
+            // if either value is equal to base, we keep THE OTHER one
+            if (baseValOpt.isPresent() && baseValOpt.get().equals(leftVal)) {
+                merged = Optional.of(rightVal);
+            } else if (baseValOpt.isPresent() && baseValOpt.get().equals(rightVal)) {
+                merged = Optional.of(leftVal);
+            } else {
+                // we need to actually work for this merge :(
+                switch (role) {
+                    case IS_IMPLICIT:
+                        if (baseValOpt.isPresent()) {
+                            merged = Optional.of(!(Boolean) baseValOpt.get());
+                        } else {
+                            // when in doubt, discard implicitness
+                            merged = Optional.of(false);
                         }
-                    }
-
-
-                    if (merged.isPresent()) {
-                        mergedRoledValues.set(i, role, merged.get());
-
-                        if (!conflictPresent)
-                            unresolvedConflicts.pop();
-                    }
+                        break;
+                    case MODIFIER:
+                        Pair<Boolean, Optional<Set<ModifierKind>>> mergePair = mergeModifierKinds(
+                                baseValOpt.map(o -> (Set<ModifierKind>) o),
+                                (Set<ModifierKind>) leftVal,
+                                (Set<ModifierKind>) rightVal);
+                        conflictPresent = mergePair.first;
+                        merged = mergePair.second;
+                        break;
+                    case COMMENT_CONTENT:
+                        merged = mergeComments(baseValOpt.orElse(""), leftVal, rightVal);
+                        break;
+                    case IS_UPPER:
+                        merged = mergeIsUpper(
+                                baseOpt.map(c -> c.getValue().getElement()),
+                                leftRoledValues.getElement(),
+                                rightRoledValues.getElement()
+                        );
+                        break;
+                    default:
+                        // pass
                 }
+            }
 
-                if (!unresolvedConflicts.isEmpty()) {
-                    // at least one conflict was not resolved
-                    pred.getElement().putMetadata(ContentConflict.METADATA_KEY, new ArrayList<>(unresolvedConflicts));
-                    hasConflict = true;
-                }
 
-                Set<Content<SpoonNode, RoledValues>> contents = new HashSet<>();
-                contents.add(new Content<>(pcs, mergedRoledValues));
-                delta.setContent(pred, contents);
+            if (merged.isPresent()) {
+                mergedRoledValues.set(i, role, merged.get());
+
+                if (!conflictPresent)
+                    unresolvedConflicts.pop();
             }
         }
-        return hasConflict;
+
+        if (!unresolvedConflicts.isEmpty()) {
+            // at least one conflict was not resolved
+            node.getElement().putMetadata(ContentConflict.METADATA_KEY, new ArrayList<>(unresolvedConflicts));
+            hasConflict = true;
+        }
+
+        return Pair.of(mergedRoledValues, hasConflict);
     }
 
-    /**
-     * Separate modifiers into visibility (public, private, protected), keywords (static, final) and all
-     * others.
-     *
-     * @param modifiers A stream of modifiers.
-     * @return A triple with visibility in first, keywords in second and other in third.
-     */
-    public static Triple<Set<ModifierKind>, Set<ModifierKind>, Set<ModifierKind>>
+        /**
+         * Separate modifiers into visibility (public, private, protected), keywords (static, final) and all
+         * others.
+         *
+         * @param modifiers A stream of modifiers.
+         * @return A triple with visibility in first, keywords in second and other in third.
+         */
+        public static Triple<Set<ModifierKind>, Set<ModifierKind>, Set<ModifierKind>>
     categorizeModifiers(Stream<ModifierKind> modifiers) {
         Set<ModifierKind> visibility = new HashSet<>();
         Set<ModifierKind> keywords = new HashSet<>();

--- a/src/main/java/se/kth/spork/spoon/PcsInterpreter.java
+++ b/src/main/java/se/kth/spork/spoon/PcsInterpreter.java
@@ -1,15 +1,6 @@
 package se.kth.spork.spoon;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -23,10 +14,8 @@ import se.kth.spork.util.Pair;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtParameterReference;
-import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 
 /**
@@ -35,10 +24,13 @@ import spoon.reflect.reference.CtTypeReference;
  * @author Simon Larsén
  */
 public class PcsInterpreter {
+    public static final String ORIGINAL_NODE_KEY = "spork_original_node";
+    public static final String SINGLE_REVISION_KEY = "spork_single_revision";
+
     private final Map<SpoonNode, Map<SpoonNode, Pcs<SpoonNode>>> rootToChildren;
     private final Map<Pcs<SpoonNode>, Set<Pcs<SpoonNode>>> structuralConflicts;
     private final Builder visitor;
-    private boolean hasConflicts;
+    private boolean hasStructuralConflicts;
 
     /**
      * Convert a merged PCS structure into a Spoon tree.
@@ -53,11 +45,11 @@ public class PcsInterpreter {
             SpoonMapping baseRight) {
         PcsInterpreter pcsInterpreter = new PcsInterpreter(delta, baseLeft, baseRight);
         pcsInterpreter.traversePcs(NodeFactory.ROOT);
-        return Pair.of(pcsInterpreter.visitor.actualRoot, pcsInterpreter.hasConflicts);
+        return Pair.of(pcsInterpreter.visitor.actualRoot, pcsInterpreter.hasConflicts());
     }
 
     private PcsInterpreter(ChangeSet<SpoonNode, RoledValues> delta, SpoonMapping baseLeft, SpoonMapping baseRight) {
-        hasConflicts = false;
+        hasStructuralConflicts = false;
         rootToChildren = buildRootToChildren(delta.getPcsSet());
         visitor = new Builder(delta.getContents(), baseLeft, baseRight);
         this.structuralConflicts = delta.getStructuralConflicts();
@@ -108,15 +100,25 @@ public class PcsInterpreter {
                 Objects.equals(left.getRoot(), right.getRoot());
     }
 
-    private void traversePcs(SpoonNode currentRoot) {
+    private Set<Revision> traversePcs(SpoonNode currentRoot) {
         Map<SpoonNode, Pcs<SpoonNode>> children = rootToChildren.get(currentRoot);
-        if (children == null) // leaf node
-            return;
 
         SpoonNode next = NodeFactory.startOfChildList(currentRoot);
+        Set<Revision> revisions = new HashSet<>();
+
+        if (currentRoot != NodeFactory.ROOT) {
+            revisions.add(currentRoot.getRevision());
+            visitor.contents.getOrDefault(currentRoot, Collections.emptySet())
+                    .forEach(content -> revisions.add(content.getContext().getRevision()));
+        }
+
+        if (children == null) // leaf node
+            return revisions;
+
         List<SpoonNode> sortedChildren = new ArrayList<>();
         while (true) {
             Pcs<SpoonNode> nextPcs = children.get(next);
+            revisions.add(nextPcs.getRevision());
 
             next = nextPcs.getSuccessor();
             if (next.isEndOfList()) {
@@ -129,6 +131,7 @@ public class PcsInterpreter {
 
             // successor conflicts mark the start of a conflict, any other conflict is to be ignored
             if (successorConflict.isPresent()) {
+                revisions.addAll(Arrays.asList(Revision.LEFT, Revision.RIGHT));
                 next = traverseConflict(nextPcs, successorConflict.get(), currentRoot, children);
             } else {
                 visitor.visit(currentRoot, next);
@@ -136,7 +139,16 @@ public class PcsInterpreter {
             }
         }
 
-        sortedChildren.forEach(this::traversePcs);
+        for (SpoonNode child : sortedChildren) {
+            Set<Revision> subtreeRevisions = traversePcs(child);
+            if (subtreeRevisions.size() == 1) {
+                // has a single revision in subtree (so can be sniper printed)
+                visitor.nodes.get(child).getElement().putMetadata(SINGLE_REVISION_KEY, subtreeRevisions.iterator().next());
+            }
+            revisions.addAll(subtreeRevisions);
+        }
+
+        return revisions;
     }
 
     /**
@@ -170,9 +182,8 @@ public class PcsInterpreter {
                 traversePcs(node);
             }
         } else {
-            hasConflicts = true;
+            hasStructuralConflicts = true;
             visitor.visitConflicting(currentRoot, leftNodes, rightNodes);
-            visitor.endConflict();
         }
 
         return leftNodes.isEmpty() ? next : leftNodes.get(leftNodes.size() - 1);
@@ -210,6 +221,13 @@ public class PcsInterpreter {
     }
 
     /**
+     * @return true if there are structural or content conflicts in the merge.
+     */
+    private boolean hasConflicts() {
+        return hasStructuralConflicts || visitor.hasContentConflict;
+    }
+
+    /**
      * Try to resolve a structural conflict automatically.
      */
     private static Optional<List<SpoonNode>> tryResolveConflict(List<SpoonNode> leftNodes, List<SpoonNode> rightNodes) {
@@ -230,7 +248,7 @@ public class PcsInterpreter {
         private Map<SpoonNode, Set<Content<SpoonNode, RoledValues>>> contents;
         private SpoonMapping baseLeft;
         private SpoonMapping baseRight;
-        private boolean inConflict = false;
+        private boolean hasContentConflict = false;
 
 
         // A mapping from a node in the input PCS structure to its copy in the merged tree
@@ -261,12 +279,17 @@ public class PcsInterpreter {
             CtElement originalTree = origTreeWrapper.getElement();
             CtElement originalRoot = origRootWrapper.getElement();
 
-            CtElement mergeTree = shallowCopyTree(originalTree);
-            if (!inConflict) {
-                // content should only be merged if not in a conflict
-                // when in a conflict, the original tree's content should always be used
-                setContent(mergeTree, origTreeWrapper);
+            // IMPORTANT: Content merging must happen before copying the tree, as the content merger sets conflict
+            // metadata (upon conflict) on the original tree.
+            Pair<RoledValues, Boolean> mergedContent =
+                    ContentMerger.mergedContent(origTreeWrapper, contents.get(origTreeWrapper));
+            if (mergedContent.second) {
+                hasContentConflict = true;
             }
+
+            CtElement mergeTree = shallowCopyTree(originalTree);
+            mergedContent.first.forEach(rv -> mergeTree.setValueByRole(rv.getRole(), rv.getValue()));
+
 
             if (mergeParent != null) {
                 CtRole mergeTreeRole = resolveRole(origTreeWrapper);
@@ -322,16 +345,13 @@ public class PcsInterpreter {
 
         /**
          * Visit the root nodes of a conflict. Note that the children of these nodes are not visited
-         * by this method, it is the responsibility of the caller to visit the children, and then call
-         * the {@link Builder#endConflict()} once the conflict has been concluded.
+         * by this method.
          *
          * @param parent The parent node of the conflict.
          * @param left   Ordered root nodes from the left part of the conflict.
          * @param right  Ordered root nodes from the right part of the conflict.
          */
         public void visitConflicting(SpoonNode parent, List<SpoonNode> left, List<SpoonNode> right) {
-            inConflict = true;
-
             CtElement mergeParent = nodes.get(parent).getElement();
             CtElement dummy = (left.size() > 0 ? left.get(0) : right.get(0)).getElement();
 
@@ -344,14 +364,6 @@ public class PcsInterpreter {
             Object inserted = withSiblings(parent.getElement(), dummy, mergeParent, dummy, role);
             dummy.delete();
             mergeParent.setValueByRole(role, inserted);
-        }
-
-        /**
-         * Signal the end of a structural conflict. Should be called when all children of the root conflict nodes
-         * have been visited.
-         */
-        public void endConflict() {
-            inConflict = false;
         }
 
         /**
@@ -461,27 +473,6 @@ public class PcsInterpreter {
 
             return mutableCurrent;
         }
-
-        /**
-         * Set the content of a tree that is being/has been merged to the merged content of the original tree.
-         *
-         * @param mergeTree    A tree in the merge output.
-         * @param originalTree A wrapper around the tree from which mergeTree was copied.
-         */
-        private void setContent(CtElement mergeTree, SpoonNode originalTree) {
-            Set<Content<SpoonNode, RoledValues>> nodeContents = contents.get(originalTree);
-
-            if (nodeContents.size() != 1) {
-                throw new IllegalStateException("Internal error, unhandled conflict: " + nodeContents);
-            } else {
-                RoledValues rvs = nodeContents.iterator().next().getValue();
-
-                for (RoledValue roledValue : rvs) {
-                    mergeTree.setValueByRole(roledValue.getRole(), roledValue.getValue());
-                }
-            }
-        }
-
     }
 
     /**
@@ -500,6 +491,7 @@ public class PcsInterpreter {
         // remove the wrapper metadata
         Map<String, Object> metadata = new HashMap<>(treeCopy.getAllMetadata());
         metadata.remove(NodeFactory.WRAPPER_METADATA);
+        metadata.put(ORIGINAL_NODE_KEY, tree);
         treeCopy.setAllMetadata(metadata);
 
         return treeCopy;

--- a/src/main/java/se/kth/spork/spoon/PcsInterpreter.java
+++ b/src/main/java/se/kth/spork/spoon/PcsInterpreter.java
@@ -279,17 +279,16 @@ public class PcsInterpreter {
             CtElement originalTree = origTreeWrapper.getElement();
             CtElement originalRoot = origRootWrapper.getElement();
 
-            // IMPORTANT: Content merging must happen before copying the tree, as the content merger sets conflict
-            // metadata (upon conflict) on the original tree.
-            Pair<RoledValues, Boolean> mergedContent =
-                    ContentMerger.mergedContent(origTreeWrapper, contents.get(origTreeWrapper));
-            if (mergedContent.second) {
-                hasContentConflict = true;
-            }
+            Pair<RoledValues, List<ContentConflict>> mergedContent =
+                    ContentMerger.mergedContent(contents.get(origTreeWrapper));
 
             CtElement mergeTree = shallowCopyTree(originalTree);
             mergedContent.first.forEach(rv -> mergeTree.setValueByRole(rv.getRole(), rv.getValue()));
-
+            if (!mergedContent.second.isEmpty()) {
+                // at least one conflict was not resolved
+                mergeTree.putMetadata(ContentConflict.METADATA_KEY, mergedContent.second);
+                hasContentConflict = true;
+            }
 
             if (mergeParent != null) {
                 CtRole mergeTreeRole = resolveRole(origTreeWrapper);
@@ -496,5 +495,4 @@ public class PcsInterpreter {
 
         return treeCopy;
     }
-
 }

--- a/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
+++ b/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
@@ -104,14 +104,12 @@ public class Spoon3dmMerge {
             TdmMerge.resolveRawMerge(t0Star, delta);
         }
 
-        boolean hasContentConflict = ContentMerger.handleContentConflicts(delta);
-
         LOGGER.info("Interpreting resolved PCS merge");
         Pair<CtElement, Boolean> merge = PcsInterpreter.fromMergedPcs(delta, baseLeft, baseRight);
         // we can be certain that the merge tree has the same root type as the three constituents, so this cast is safe
         @SuppressWarnings("unchecked")
         T mergeTree = (T) merge.first;
-        boolean hasStructuralConflicts = merge.second;
+        boolean hasConflicts = merge.second;
 
         LOGGER.info("Merging import statements");
         List<CtImport> mergedImports = mergeImportStatements(base, left, right);
@@ -119,7 +117,7 @@ public class Spoon3dmMerge {
 
         LOGGER.info("Merged in " + (double) (System.nanoTime() - start) / 1e9 + " seconds");
 
-        return Pair.of(mergeTree, hasContentConflict || hasStructuralConflicts);
+        return Pair.of(mergeTree, hasConflicts);
     }
 
     /**

--- a/src/test/java/se/kth/spork/Util.java
+++ b/src/test/java/se/kth/spork/Util.java
@@ -7,7 +7,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import se.kth.spork.cli.SporkPrettyPrinter;
 import spoon.Launcher;
+import spoon.compiler.Environment;
+import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtModule;
+import spoon.support.compiler.FileSystemFile;
+import spoon.support.sniper.SniperJavaPrettyPrinter;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +36,7 @@ public class Util {
     public static final Path BOTH_MODIFIED_DIRPATH = CLEAN_MERGE_DIRPATH.resolve("both_modified");
     public static final Path LEFT_MODIFIED_DIRPATH = CLEAN_MERGE_DIRPATH.resolve("left_modified");
     public static final Path CONFLICT_DIRPATH = Paths.get("src/test/resources/conflict");
+    public static final Path REALWORLD_DIRPATH = Paths.get("src/test/resources/realworld");
 
     /**
      * Provides test sources for scenarios where both left and right revisions are modified.
@@ -77,6 +84,16 @@ public class Util {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
             return getArgumentSourcesStream(CONFLICT_DIRPATH.toFile());
+        }
+    }
+
+    /**
+     * Provides test sources for real-world scenarios.
+     */
+    public static class RealWorldSourceProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            return getArgumentSourcesStream(REALWORLD_DIRPATH.toFile());
         }
     }
 
@@ -143,6 +160,36 @@ public class Util {
         return leftMarkerMatcher.replaceAll("");
     }
 
+    /**
+     * Return a copy of the string that has no blank/whitespace only lines.
+     */
+    public static String withoutBlankLines(String s) {
+        String[] lines = s.split("\n");
+        List<String> sb = new ArrayList<>();
+        for (String line : lines) {
+            if (!line.matches("^\\s*$")) {
+                sb.add(line);
+            }
+        }
+        return String.join("\n", sb);
+    }
+
+    public static CtModule sniperParse(Path path) {
+        Launcher launcher = new Launcher();
+        Environment env = launcher.getEnvironment();
+        env.setPrettyPrinterCreator(() -> new SniperJavaPrettyPrinter(env));
+        launcher.addInputResource(new FileSystemFile(path.toFile()));
+
+        CtModel model = launcher.buildModel();
+
+        return model.getUnnamedModule();
+    }
+
+    public static String sniperPrint(CtModule mod) {
+        CtCompilationUnit cu = mod.getFactory().CompilationUnit().getOrCreate(mod.getRootPackage());
+        return new SniperJavaPrettyPrinter(mod.getFactory().getEnvironment()).printCompilationUnit(cu);
+    }
+
     public static class Conflict {
         String left;
         String right;
@@ -169,6 +216,7 @@ public class Util {
             return Objects.hash(left, right);
         }
     }
+
 
     public static class TestSources {
         public Path base;

--- a/src/test/java/se/kth/spork/Util.java
+++ b/src/test/java/se/kth/spork/Util.java
@@ -42,7 +42,7 @@ public class Util {
      */
     public static class BothModifiedSourceProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return getArgumentSourcesStream(BOTH_MODIFIED_DIRPATH.toFile());
         }
     }
@@ -52,7 +52,7 @@ public class Util {
      */
     public static class LeftModifiedSourceProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return getArgumentSourcesStream(LEFT_MODIFIED_DIRPATH.toFile());
         }
     }
@@ -62,7 +62,7 @@ public class Util {
      */
     public static class RightModifiedSourceProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return getArgumentSourcesStream(LEFT_MODIFIED_DIRPATH.toFile()).map(
                     arg -> {
                         TestSources sources = (TestSources) arg.get()[0];
@@ -81,7 +81,7 @@ public class Util {
      */
     public static class ConflictSourceProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return getArgumentSourcesStream(CONFLICT_DIRPATH.toFile());
         }
     }

--- a/src/test/java/se/kth/spork/Util.java
+++ b/src/test/java/se/kth/spork/Util.java
@@ -36,7 +36,6 @@ public class Util {
     public static final Path BOTH_MODIFIED_DIRPATH = CLEAN_MERGE_DIRPATH.resolve("both_modified");
     public static final Path LEFT_MODIFIED_DIRPATH = CLEAN_MERGE_DIRPATH.resolve("left_modified");
     public static final Path CONFLICT_DIRPATH = Paths.get("src/test/resources/conflict");
-    public static final Path REALWORLD_DIRPATH = Paths.get("src/test/resources/realworld");
 
     /**
      * Provides test sources for scenarios where both left and right revisions are modified.
@@ -84,16 +83,6 @@ public class Util {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
             return getArgumentSourcesStream(CONFLICT_DIRPATH.toFile());
-        }
-    }
-
-    /**
-     * Provides test sources for real-world scenarios.
-     */
-    public static class RealWorldSourceProvider implements ArgumentsProvider {
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
-            return getArgumentSourcesStream(REALWORLD_DIRPATH.toFile());
         }
     }
 
@@ -158,36 +147,6 @@ public class Util {
         Pattern leftConflictMarkerPattern = Pattern.compile(SporkPrettyPrinter.START_CONFLICT);
         Matcher leftMarkerMatcher = leftConflictMarkerPattern.matcher(rightRevStrippend);
         return leftMarkerMatcher.replaceAll("");
-    }
-
-    /**
-     * Return a copy of the string that has no blank/whitespace only lines.
-     */
-    public static String withoutBlankLines(String s) {
-        String[] lines = s.split("\n");
-        List<String> sb = new ArrayList<>();
-        for (String line : lines) {
-            if (!line.matches("^\\s*$")) {
-                sb.add(line);
-            }
-        }
-        return String.join("\n", sb);
-    }
-
-    public static CtModule sniperParse(Path path) {
-        Launcher launcher = new Launcher();
-        Environment env = launcher.getEnvironment();
-        env.setPrettyPrinterCreator(() -> new SniperJavaPrettyPrinter(env));
-        launcher.addInputResource(new FileSystemFile(path.toFile()));
-
-        CtModel model = launcher.buildModel();
-
-        return model.getUnnamedModule();
-    }
-
-    public static String sniperPrint(CtModule mod) {
-        CtCompilationUnit cu = mod.getFactory().CompilationUnit().getOrCreate(mod.getRootPackage());
-        return new SniperJavaPrettyPrinter(mod.getFactory().getEnvironment()).printCompilationUnit(cu);
     }
 
     public static class Conflict {

--- a/src/test/java/se/kth/spork/cli/CliTest.java
+++ b/src/test/java/se/kth/spork/cli/CliTest.java
@@ -115,15 +115,8 @@ class CliTest {
         Files.write(outFile, expectedPrettyPrint.getBytes(), StandardOpenOption.CREATE);
 
         CtModule reParsedMerge = Parser.parse(outFile);
-        String reParsedPrettyPRint = Cli.prettyPrint(reParsedMerge);
         Object reParsedImports = reParsedMerge.getMetadata(Parser.IMPORT_STATEMENTS);
 
-        // this assert is to give a better diff when there are obvious failures
-        // it will most likely miss consistent errors in the pretty printer
-        assertEquals(expectedPrettyPrint, reParsedPrettyPRint);
-
-        // this assert is much more detailed, it should catch everything that exists inside the Spoon tree
-        // that could potentially be lost in a pretty-print
         assertEquals(mergeTree, reParsedMerge);
 
         assertEquals(reParsedImports, expectedImports);

--- a/src/test/java/se/kth/spork/spoon/Spoon3dmMergeTest.java
+++ b/src/test/java/se/kth/spork/spoon/Spoon3dmMergeTest.java
@@ -46,7 +46,7 @@ class Spoon3dmMergeTest {
 
         // this assert is just to give a better overview of obvious errors, but it relies on the pretty printer's
         // correctness
-        assertEquals(Cli.prettyPrint(expected), Cli.prettyPrint(mergeTree));
+        //assertEquals(Cli.prettyPrint(expected), Cli.prettyPrint(mergeTree));
 
         // these asserts are what actually matters
         assertEquals(expected, mergeTree);


### PR DESCRIPTION
Fix #95 

This PR is a bit of a monster, so I'll squash it. I just don't have time to make it pretty.

The major feature of this PR is that the PcsInterpreter has been changed to keep track of which revisions appear in which subtrees. If a subtree is found to contain only a single revision, then the interpreter sets metadata on the node to indicate that.

When the pretty printer finds such metadata on a method or field node, it does not attempt to print it but instead extracts the original source code and prints that, all the while attempting to match indentation. It seems like it works.

Checking pretty print vs reparsed pretty print in tests no longer works as a result of this, however.

The ContentMerger has also been refactored not to have any side effects, which was necessary to make this all work. The source code extraction functionality of the pretty printer has been moved to a separate class.