### PR TITLE
[fix] Introduce intermediate virtual nodes for select concrete nodes

### DIFF
--- a/src/main/java/se/kth/spork/base3dm/ChangeSet.java
+++ b/src/main/java/se/kth/spork/base3dm/ChangeSet.java
@@ -196,7 +196,7 @@ public class ChangeSet<T extends ListNode,V> {
                 addToLookupTable(classRepPred, classRepPcs, predecessors);
                 addToLookupTable(classRepSucc, classRepPcs, successors);
             }
-            if (!pred.isListEdge()) {
+            if (!pred.isVirtual()) {
                 Content<T,V> c = new Content<T,V>(pcs, getContent.apply(pred));
                 addToLookupTable(classRepPred, c, content);
             }
@@ -204,10 +204,10 @@ public class ChangeSet<T extends ListNode,V> {
     }
 
     private Pcs<T> addToStar(Pcs<T> pcs) {
-        T root = pcs.getRoot();
-        T pred = pcs.getPredecessor();
-        T succ = pcs.getSuccessor();
-        Pcs<T> classRepPcs = new Pcs<T>(classRepMap.get(root), classRepMap.get(pred), classRepMap.get(succ), pcs.getRevision());
+        T root = classRepMap.get(pcs.getRoot());
+        T pred = classRepMap.get(pcs.getPredecessor());
+        T succ = classRepMap.get(pcs.getSuccessor());
+        Pcs<T> classRepPcs = new Pcs<T>(root, pred, succ, pcs.getRevision());
         pcsSet.add(classRepPcs);
         return classRepPcs;
     }

--- a/src/main/java/se/kth/spork/base3dm/ListNode.java
+++ b/src/main/java/se/kth/spork/base3dm/ListNode.java
@@ -27,4 +27,11 @@ public interface ListNode {
     default boolean isListEdge() {
         return isStartOfList() || isEndOfList();
     }
+
+    /**
+     * @return true iff this node is a virtual node.
+     */
+    default boolean isVirtual() {
+        return isListEdge();
+    }
 }

--- a/src/main/java/se/kth/spork/base3dm/Pcs.java
+++ b/src/main/java/se/kth/spork/base3dm/Pcs.java
@@ -21,6 +21,10 @@ public class Pcs<T extends ListNode> {
      * @param revision The revision this PCS is related to.
      */
     public Pcs(T root, T predecessor, T successor, Revision revision) {
+        if (root == null || predecessor == null || successor == null) {
+            throw new IllegalArgumentException("nodes may not be null");
+        }
+
         this.root = root;
         this.predecessor = predecessor;
         this.successor = successor;

--- a/src/main/java/se/kth/spork/spoon/PcsBuilder.java
+++ b/src/main/java/se/kth/spork/spoon/PcsBuilder.java
@@ -71,10 +71,22 @@ class PcsBuilder extends CtScanner {
                 SpoonNode pred = lastSibling;
                 for (SpoonNode succ : virtualNodes.subList(1, virtualNodes.size())) {
                     pcses.add(new Pcs<>(parent, pred, succ, revision));
+
+                    // also need to create "leaf child lists" for any non-list-edge virtual node that does not have any
+                    // children, or Spork will not discover removals that entirely empty the child list.
+                    // The problem is detailed in https://github.com/KTH/spork/issues/116
+                    if (!pred.isListEdge() && !parentToLastSibling.containsKey(pred)) {
+                        pcses.add(createLeafPcs(pred));
+                    }
+
                     pred = succ;
                 }
             }
         }
+    }
+
+    private Pcs<SpoonNode> createLeafPcs(SpoonNode node) {
+        return new Pcs<>(node, NodeFactory.startOfChildList(node), NodeFactory.endOfChildList(node), revision);
     }
 
     public Set<Pcs<SpoonNode>> getPcses() {

--- a/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
+++ b/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
@@ -77,6 +77,11 @@ public class Spoon3dmMerge {
         Matcher baseRightGumtreeMatch = matchTrees(baseGumtree, rightGumtree);
         Matcher leftRightGumtreeMatch = matchTreesXY(leftGumtree, rightGumtree);
 
+        LOGGER.info(() -> "Converting Spoon trees to PCS triples");
+        Set<Pcs<SpoonNode>> t0 = PcsBuilder.fromSpoon(base, Revision.BASE);
+        Set<Pcs<SpoonNode>> t1 = PcsBuilder.fromSpoon(left, Revision.LEFT);
+        Set<Pcs<SpoonNode>> t2 = PcsBuilder.fromSpoon(right, Revision.RIGHT);
+
         LOGGER.info(() -> "Converting GumTree matches to Spoon matches");
         SpoonMapping baseLeft = SpoonMapping.fromGumTreeMapping(baseLeftGumtreeMatch.getMappings());
         SpoonMapping baseRight = SpoonMapping.fromGumTreeMapping(baseRightGumtreeMatch.getMappings());
@@ -86,11 +91,6 @@ public class Spoon3dmMerge {
         LOGGER.info(() -> "Mapping nodes to class representatives");
         Map<SpoonNode, SpoonNode> classRepMap = ClassRepresentatives.createClassRepresentativesMapping(
                 base, left, right, baseLeft, baseRight, leftRight);
-
-        LOGGER.info(() -> "Converting Spoon trees to PCS triples");
-        Set<Pcs<SpoonNode>> t0 = PcsBuilder.fromSpoon(base, Revision.BASE);
-        Set<Pcs<SpoonNode>> t1 = PcsBuilder.fromSpoon(left, Revision.LEFT);
-        Set<Pcs<SpoonNode>> t2 = PcsBuilder.fromSpoon(right, Revision.RIGHT);
 
         LOGGER.info(() -> "Computing raw PCS merge");
         ChangeSet<SpoonNode, RoledValues> delta = new ChangeSet<>(classRepMap, new ContentResolver(), t0, t1, t2);

--- a/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
+++ b/src/main/java/se/kth/spork/spoon/Spoon3dmMerge.java
@@ -77,11 +77,6 @@ public class Spoon3dmMerge {
         Matcher baseRightGumtreeMatch = matchTrees(baseGumtree, rightGumtree);
         Matcher leftRightGumtreeMatch = matchTreesXY(leftGumtree, rightGumtree);
 
-        LOGGER.info(() -> "Converting Spoon trees to PCS triples");
-        Set<Pcs<SpoonNode>> t0 = PcsBuilder.fromSpoon(base, Revision.BASE);
-        Set<Pcs<SpoonNode>> t1 = PcsBuilder.fromSpoon(left, Revision.LEFT);
-        Set<Pcs<SpoonNode>> t2 = PcsBuilder.fromSpoon(right, Revision.RIGHT);
-
         LOGGER.info(() -> "Converting GumTree matches to Spoon matches");
         SpoonMapping baseLeft = SpoonMapping.fromGumTreeMapping(baseLeftGumtreeMatch.getMappings());
         SpoonMapping baseRight = SpoonMapping.fromGumTreeMapping(baseRightGumtreeMatch.getMappings());
@@ -91,6 +86,11 @@ public class Spoon3dmMerge {
         LOGGER.info(() -> "Mapping nodes to class representatives");
         Map<SpoonNode, SpoonNode> classRepMap = ClassRepresentatives.createClassRepresentativesMapping(
                 base, left, right, baseLeft, baseRight, leftRight);
+
+        LOGGER.info(() -> "Converting Spoon trees to PCS triples");
+        Set<Pcs<SpoonNode>> t0 = PcsBuilder.fromSpoon(base, Revision.BASE);
+        Set<Pcs<SpoonNode>> t1 = PcsBuilder.fromSpoon(left, Revision.LEFT);
+        Set<Pcs<SpoonNode>> t2 = PcsBuilder.fromSpoon(right, Revision.RIGHT);
 
         LOGGER.info(() -> "Computing raw PCS merge");
         ChangeSet<SpoonNode, RoledValues> delta = new ChangeSet<>(classRepMap, new ContentResolver(), t0, t1, t2);

--- a/src/main/java/se/kth/spork/spoon/matching/ClassRepresentatives.java
+++ b/src/main/java/se/kth/spork/spoon/matching/ClassRepresentatives.java
@@ -101,17 +101,6 @@ public class ClassRepresentatives {
             CtElement t = descIt.next();
             mapToClassRep(mappings, classRepMap, rev, t);
         }
-
-        descIt = tree.descendantIterator();
-        while (descIt.hasNext()) {
-            CtElement t = descIt.next();
-            SpoonNode node = NodeFactory.wrap(t);
-            SpoonNode parent = node.getParent();
-            SpoonNode parentClassRep = classRepMap.get(parent);
-            if (parentClassRep == null) {
-                System.out.println();
-            }
-        }
     }
 
     private static void mapToClassRep(SpoonMapping mappings, Map<SpoonNode, SpoonNode> classRepMap, Revision rev, CtElement t) {

--- a/src/main/java/se/kth/spork/spoon/matching/ClassRepresentatives.java
+++ b/src/main/java/se/kth/spork/spoon/matching/ClassRepresentatives.java
@@ -5,10 +5,12 @@ import se.kth.spork.base3dm.TdmMerge;
 import se.kth.spork.spoon.wrappers.SpoonNode;
 import se.kth.spork.spoon.wrappers.NodeFactory;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.visitor.CtScanner;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -99,6 +101,17 @@ public class ClassRepresentatives {
             CtElement t = descIt.next();
             mapToClassRep(mappings, classRepMap, rev, t);
         }
+
+        descIt = tree.descendantIterator();
+        while (descIt.hasNext()) {
+            CtElement t = descIt.next();
+            SpoonNode node = NodeFactory.wrap(t);
+            SpoonNode parent = node.getParent();
+            SpoonNode parentClassRep = classRepMap.get(parent);
+            if (parentClassRep == null) {
+                System.out.println();
+            }
+        }
     }
 
     private static void mapToClassRep(SpoonMapping mappings, Map<SpoonNode, SpoonNode> classRepMap, Revision rev, CtElement t) {
@@ -126,13 +139,19 @@ public class ClassRepresentatives {
         classRepMap.put(from, to);
 
         // map the virtual nodes
-        SpoonNode fromSOL = NodeFactory.startOfChildList(from);
-        SpoonNode toSOL = NodeFactory.startOfChildList(to);
-        SpoonNode fromEOL = NodeFactory.endOfChildList(from);
-        SpoonNode toEOL = NodeFactory.endOfChildList(to);
+        List<SpoonNode> fromVirtualNodes = from.getVirtualNodes();
+        List<SpoonNode> toVirtualNodes = to.getVirtualNodes();
 
-        classRepMap.put(fromSOL, toSOL);
-        classRepMap.put(fromEOL, toEOL);
+        for (int i = 0; i < fromVirtualNodes.size(); i++) {
+            SpoonNode fromVirt = fromVirtualNodes.get(i);
+            SpoonNode toVirt = toVirtualNodes.get(i);
+
+            if (fromVirt.isListEdge()) {
+                classRepMap.put(fromVirt, toVirt);
+            } else {
+                mapNodes(fromVirt, toVirt, classRepMap);
+            }
+        }
     }
 
     /**

--- a/src/main/java/se/kth/spork/spoon/matching/SpoonMapping.java
+++ b/src/main/java/se/kth/spork/spoon/matching/SpoonMapping.java
@@ -4,6 +4,7 @@ import com.github.gumtreediff.matchers.Mapping;
 import com.github.gumtreediff.matchers.MappingStore;
 import com.github.gumtreediff.tree.ITree;
 import com.github.gumtreediff.utils.Pair;
+import gumtree.spoon.builder.CtWrapper;
 import gumtree.spoon.builder.SpoonGumTreeBuilder;
 import se.kth.spork.spoon.wrappers.SpoonNode;
 import se.kth.spork.spoon.wrappers.NodeFactory;
@@ -97,6 +98,9 @@ public class SpoonMapping {
             // that the keys in the annotation map aren't proper nodes.
             return true;
         } else if (isPrimitiveType(src) != isPrimitiveType(dst)) {
+            return true;
+        } else if (src instanceof CtWrapper || dst instanceof CtWrapper) {
+            // the CtWrapper elements do not represent real Spoon nodes, and so are just noise
             return true;
         }
         return false;

--- a/src/main/java/se/kth/spork/spoon/pcsinterpreter/SpoonTreeBuilder.java
+++ b/src/main/java/se/kth/spork/spoon/pcsinterpreter/SpoonTreeBuilder.java
@@ -187,6 +187,9 @@ public class SpoonTreeBuilder {
             }
         }
 
+        // NOTE: Super important that the parent of the merge tree is set no matter what, as wrapping a spoon CtElement
+        // in a SpoonNode requires access to its parent.
+        mergeTree.setParent(mergeParent);
         nodes.put(origTreeNode, NodeFactory.wrap(mergeTree));
 
         return mergeTree;

--- a/src/main/java/se/kth/spork/spoon/wrappers/NodeFactory.java
+++ b/src/main/java/se/kth/spork/spoon/wrappers/NodeFactory.java
@@ -4,6 +4,7 @@ import se.kth.spork.base3dm.Revision;
 import se.kth.spork.base3dm.TdmMerge;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.ModuleFactory;
 import spoon.reflect.meta.RoleHandler;
 import spoon.reflect.meta.impl.RoleHandlerHelper;
@@ -34,12 +35,13 @@ public class NodeFactory {
 
     private static final Map<Class<? extends CtElement>, List<CtRole>> EXPLODED_TYPE_ROLES;
     private static final List<Class<? extends CtElement>> EXPLODED_TYPES = Arrays.asList(
-            CtExecutableReference.class, CtExecutable.class
+            CtExecutableReference.class, CtExecutable.class, CtType.class
     );
 
-    // These are roles that are present in the EXPLODED_TYPES types, but are not structural and therefore
-    // do not add any value in the PCS structure. When adding a new exploded type,
+    // These are roles that are present in the EXPLODED_TYPES types, but are either not structural
+    // or are always present as a single node (such as a method body)
     private static final Set<CtRole> IGNORED_ROLES = Stream.of(
+            /* START NON-STRUCTURAL ROLES */
             CtRole.IS_IMPLICIT,
             CtRole.IS_DEFAULT,
             CtRole.IS_VARARGS,
@@ -49,10 +51,13 @@ public class NodeFactory {
             CtRole.DECLARING_TYPE,
             CtRole.MODIFIER,
             CtRole.EMODIFIER,
-            CtRole.COMMENT,
             CtRole.NAME,
-            CtRole.BODY,
-            CtRole.POSITION
+            CtRole.POSITION,
+            /* END NON-STRUCTURAL ROLES */
+            CtRole.BODY,        // always present as a single node
+            CtRole.NESTED_TYPE, // falls under type member
+            CtRole.FIELD,       // falls under type member
+            CtRole.METHOD       // falls under type member
     ).collect(Collectors.toSet());
 
     static {

--- a/src/main/java/se/kth/spork/spoon/wrappers/NodeFactory.java
+++ b/src/main/java/se/kth/spork/spoon/wrappers/NodeFactory.java
@@ -4,8 +4,17 @@ import se.kth.spork.base3dm.Revision;
 import se.kth.spork.base3dm.TdmMerge;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.ModuleFactory;
+import spoon.reflect.path.CtRole;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Wraps a CtElement and stores the wrapper in the CtElement's metadata.
@@ -25,15 +34,27 @@ public class NodeFactory {
      * @param elem An element to wrap.
      * @return A wrapper around the CtElement that is more practical for hashing purposes.
      */
-    public static SpoonNode wrap(CtElement elem) {
+    public static Node wrap(CtElement elem) {
         Object wrapper = elem.getMetadata(WRAPPER_METADATA);
 
         if (wrapper == null) {
-            wrapper = new Node(elem, currentKey++);
-            elem.putMetadata(WRAPPER_METADATA, wrapper);
+            //throw new IllegalStateException("wrapper not initialized for " + elem);
+            CtElement parent = elem.getParent();
+            return initializeWrapper(elem, parent == null ? ROOT : wrap(parent));
         }
 
-        return (SpoonNode) wrapper;
+        return (Node) wrapper;
+    }
+
+    public static Node initializeRoledWrapper(CtElement elem, Node parent) {
+        SpoonNode effectiveParent = parent.getRoleNode(elem.getRoleInParent());
+        return initializeWrapper(elem, effectiveParent);
+    }
+
+    public static Node initializeWrapper(CtElement elem, SpoonNode parent) {
+        Node node = new Node(elem, parent, currentKey++);
+        elem.putMetadata(WRAPPER_METADATA, node);
+        return node;
     }
 
     /**
@@ -60,16 +81,22 @@ public class NodeFactory {
      * A simple wrapper class for a Spoon CtElement. The reason it is needed is that the 3DM merge implementation
      * uses lookup tables, and CtElements have very heavy-duty equals and hash functions. For the purpose of 3DM merge,
      * only reference equality is needed, not deep equality.
-     *
-     * This class should only be instantiated with the CtWrapperFactory singleton.
+     * <p>
+     * This class should only be instantiated {@link NodeFactory#wrap(CtElement)}.
      */
-    private static class Node implements SpoonNode {
+    public static class Node implements SpoonNode {
         private final CtElement element;
         private final long key;
+        private final SpoonNode parent;
+        private final Map<CtRole, RoleNode> childRoles;
+        private final CtRole role;
 
-        Node(CtElement element, long key) {
+        Node(CtElement element, SpoonNode parent, long key) {
             this.element = element;
             this.key = key;
+            childRoles = new TreeMap<>();
+            this.role = element.getRoleInParent();
+            this.parent = parent;
         }
 
         @Override
@@ -79,9 +106,7 @@ public class NodeFactory {
 
         @Override
         public SpoonNode getParent() {
-            if (element instanceof ModuleFactory.CtUnnamedModule)
-                return NodeFactory.ROOT;
-            return wrap(element.getParent());
+            return parent;
         }
 
         @Override
@@ -103,6 +128,22 @@ public class NodeFactory {
         }
 
         @Override
+        public boolean isVirtual() {
+            return false;
+        }
+
+        @Override
+        public List<SpoonNode> getVirtualNodes() {
+            return Stream.concat(
+                    Stream.concat(
+                            Stream.of(NodeFactory.startOfChildList(this)),
+                            childRoles.values().stream()
+                    ),
+                    Stream.of(NodeFactory.endOfChildList(this)))
+                    .collect(Collectors.toList());
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
@@ -113,6 +154,19 @@ public class NodeFactory {
         @Override
         public int hashCode() {
             return Objects.hash(key);
+        }
+
+        public RoleNode getRoleNode(CtRole role) {
+            RoleNode roleNode = childRoles.get(role);
+            if (roleNode == null) {
+                roleNode = new RoleNode(role, this);
+                childRoles.put(role, roleNode);
+            }
+            return roleNode;
+        }
+
+        public List<RoleNode> getChildRoles() {
+            return new ArrayList<>(childRoles.values());
         }
     }
 
@@ -135,6 +189,16 @@ public class NodeFactory {
         @Override
         public Revision getRevision() {
             throw new UnsupportedOperationException("The virtual root has no revision");
+        }
+
+        @Override
+        public boolean isVirtual() {
+            return true;
+        }
+
+        @Override
+        public List<SpoonNode> getVirtualNodes() {
+            return Arrays.asList(NodeFactory.startOfChildList(this), NodeFactory.endOfChildList(this));
         }
     }
 
@@ -171,6 +235,11 @@ public class NodeFactory {
         }
 
         @Override
+        public List<SpoonNode> getVirtualNodes() {
+            return null;
+        }
+
+        @Override
         public boolean isEndOfList() {
             return side == Side.END;
         }
@@ -198,6 +267,60 @@ public class NodeFactory {
         @Override
         public String toString() {
             return side.toString();
+        }
+    }
+
+    public static class RoleNode implements SpoonNode {
+        private final Node parent;
+        private final CtRole role;
+
+        RoleNode(CtRole role, Node parent) {
+            this.role = role;
+            this.parent = parent;
+        }
+
+        @Override
+        public CtElement getElement() {
+            throw new UnsupportedOperationException("Can't get element from a RoleNode");
+        }
+
+        @Override
+        public SpoonNode getParent() {
+            return parent;
+        }
+
+        @Override
+        public Revision getRevision() {
+            return parent.getRevision();
+        }
+
+        @Override
+        public List<SpoonNode> getVirtualNodes() {
+            return Arrays.asList(NodeFactory.startOfChildList(this), NodeFactory.endOfChildList(this));
+        }
+
+        @Override
+        public String toString() {
+            return "RoleNode#" + role.toString();
+        }
+
+        @Override
+        public boolean isVirtual() {
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            RoleNode roleNode = (RoleNode) o;
+            return Objects.equals(parent, roleNode.parent) &&
+                    role == roleNode.role;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(parent, role);
         }
     }
 }

--- a/src/main/java/se/kth/spork/spoon/wrappers/SpoonNode.java
+++ b/src/main/java/se/kth/spork/spoon/wrappers/SpoonNode.java
@@ -4,10 +4,14 @@ import se.kth.spork.base3dm.ListNode;
 import se.kth.spork.base3dm.Revision;
 import spoon.reflect.declaration.CtElement;
 
+import java.util.List;
+
 public interface SpoonNode extends ListNode {
     CtElement getElement();
 
     SpoonNode getParent();
 
     Revision getRevision();
+
+    List<SpoonNode> getVirtualNodes();
 }

--- a/src/test/java/se/kth/spork/spoon/Spoon3dmMergeTest.java
+++ b/src/test/java/se/kth/spork/spoon/Spoon3dmMergeTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import se.kth.spork.Util;
+import se.kth.spork.cli.Cli;
 import se.kth.spork.exception.ConflictException;
 import se.kth.spork.util.Pair;
 import spoon.reflect.declaration.*;

--- a/src/test/resources/clean/both_modified/add_parameters_and_thrown_types/Base.java
+++ b/src/test/resources/clean/both_modified/add_parameters_and_thrown_types/Base.java
@@ -1,0 +1,5 @@
+public class Main {
+    public int add(int a, int b) {
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/both_modified/add_parameters_and_thrown_types/Expected.java
+++ b/src/test/resources/clean/both_modified/add_parameters_and_thrown_types/Expected.java
@@ -1,0 +1,5 @@
+public class Main {
+    public int add(int a, int b, int c) throws IllegalArgumentException {
+        return a + b + c;
+    }
+}

--- a/src/test/resources/clean/both_modified/add_parameters_and_thrown_types/Left.java
+++ b/src/test/resources/clean/both_modified/add_parameters_and_thrown_types/Left.java
@@ -1,0 +1,5 @@
+public class Main {
+    public int add(int a, int b) throws IllegalArgumentException {
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/both_modified/add_parameters_and_thrown_types/Right.java
+++ b/src/test/resources/clean/both_modified/add_parameters_and_thrown_types/Right.java
@@ -1,0 +1,5 @@
+public class Main {
+    public int add(int a, int b, int c) {
+        return a + b + c;
+    }
+}

--- a/src/test/resources/clean/both_modified/add_type_member_and_comment/Base.java
+++ b/src/test/resources/clean/both_modified/add_type_member_and_comment/Base.java
@@ -1,0 +1,5 @@
+package main;
+
+class Main {
+
+}

--- a/src/test/resources/clean/both_modified/add_type_member_and_comment/Expected.java
+++ b/src/test/resources/clean/both_modified/add_type_member_and_comment/Expected.java
@@ -1,0 +1,6 @@
+package main;
+
+// this is a comment that will appear at the end of the direct children of this class
+class Main {
+    int a = 2;
+}

--- a/src/test/resources/clean/both_modified/add_type_member_and_comment/Left.java
+++ b/src/test/resources/clean/both_modified/add_type_member_and_comment/Left.java
@@ -1,0 +1,5 @@
+package main;
+
+class Main {
+    int a = 2;
+}

--- a/src/test/resources/clean/both_modified/add_type_member_and_comment/Right.java
+++ b/src/test/resources/clean/both_modified/add_type_member_and_comment/Right.java
@@ -1,0 +1,6 @@
+package main;
+
+// this is a comment that will appear at the end of the direct children of this class
+class Main {
+
+}

--- a/src/test/resources/clean/left_modified/empty_parameter_list/Base.java
+++ b/src/test/resources/clean/left_modified/empty_parameter_list/Base.java
@@ -1,0 +1,5 @@
+public class Main {
+    int generateNumber(int a, int b) {
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/empty_parameter_list/Expected.java
+++ b/src/test/resources/clean/left_modified/empty_parameter_list/Expected.java
@@ -1,0 +1,5 @@
+public class Main {
+    int generateNumber() {
+        return 42;
+    }
+}

--- a/src/test/resources/clean/left_modified/empty_parameter_list/Left.java
+++ b/src/test/resources/clean/left_modified/empty_parameter_list/Left.java
@@ -1,0 +1,5 @@
+public class Main {
+    int generateNumber() {
+        return 42;
+    }
+}

--- a/src/test/resources/clean/left_modified/empty_parameter_list/Right.java
+++ b/src/test/resources/clean/left_modified/empty_parameter_list/Right.java
@@ -1,0 +1,5 @@
+public class Main {
+    int generateNumber(int a, int b) {
+        return a + b;
+    }
+}

--- a/src/test/resources/clean/left_modified/empty_thrown_types/Base.java
+++ b/src/test/resources/clean/left_modified/empty_thrown_types/Base.java
@@ -1,0 +1,7 @@
+import java.io.IOException;
+import java.util.EmptyStackException;
+
+public class Main {
+    int method() throws EmptyStackException, IOException {
+    }
+}

--- a/src/test/resources/clean/left_modified/empty_thrown_types/Expected.java
+++ b/src/test/resources/clean/left_modified/empty_thrown_types/Expected.java
@@ -1,0 +1,4 @@
+public class Main {
+    int method() {
+    }
+}

--- a/src/test/resources/clean/left_modified/empty_thrown_types/Left.java
+++ b/src/test/resources/clean/left_modified/empty_thrown_types/Left.java
@@ -1,0 +1,4 @@
+public class Main {
+    int method() {
+    }
+}

--- a/src/test/resources/clean/left_modified/empty_thrown_types/Right.java
+++ b/src/test/resources/clean/left_modified/empty_thrown_types/Right.java
@@ -1,0 +1,7 @@
+import java.io.IOException;
+import java.util.EmptyStackException;
+
+public class Main {
+    int method() throws EmptyStackException, IOException {
+    }
+}

--- a/src/test/resources/clean/left_modified/generify_method/Expected.java
+++ b/src/test/resources/clean/left_modified/generify_method/Expected.java
@@ -1,5 +1,5 @@
 public class Cls {
-    public void <T> method(List<T> list) {
+    public <T> void method(List<T> list) {
         System.out.println(list);
     }
 }

--- a/src/test/resources/clean/left_modified/generify_method/Left.java
+++ b/src/test/resources/clean/left_modified/generify_method/Left.java
@@ -1,5 +1,5 @@
 public class Cls {
-    public void <T> method(List<T> list) {
+    public <T> void method(List<T> list) {
         System.out.println(list);
     }
 }


### PR DESCRIPTION
Fix #132 

This PR introduces virtual nodes to create a layer of indirection between certain complex nodes and their child lists. This is necessary where nodes have varying amounts of certain types of children, and these children are adjacent in the "flat" representation, as otherwise there may be conflicts across syntactical boundaries.

Only a select few nodes are "exploded" with virtual nodes. Currently, it is only subtypes of `CtType`, `CtExecutable` and `CtExecutableReference`. To add a new type, simply add it to the list in `NodeFactory.EXPLODED_TYPES`.