### PR TITLE
[misc] Use Spoon 8.4.0-beta-14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,18 +15,11 @@
         <kotlin.version>1.3.72</kotlin.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
-            <groupId>com.github.inria</groupId>
-            <artifactId>spoon</artifactId>
-            <version>8498c0e74b23f1c100ccac31a417ffd610e06dc6</version>
+            <groupId>fr.inria.gforge.spoon</groupId>
+            <artifactId>spoon-core</artifactId>
+            <version>8.4.0-beta-14</version>
         </dependency>
         <dependency>
             <groupId>fr.inria.gforge.spoon.labs</groupId>


### PR DESCRIPTION
This also removes the need for Jitpack, which slows down the build