### PR TITLE
[fact] Treat Kotlin compiler warnings as errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,9 @@
                 </executions>
                 <configuration>
                     <jvmTarget>1.8</jvmTarget>
+                    <args>
+                        <arg>-Werror</arg>
+                    </args>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/kotlin/se/kth/spork/base3dm/ChangeSet.kt
+++ b/src/main/kotlin/se/kth/spork/base3dm/ChangeSet.kt
@@ -158,7 +158,7 @@ class ChangeSet<T : ListNode, V>(private val classRepMap: Map<T, T>, getContent:
 
     companion object {
         private fun <K, V> addToLookupTable(key: K, `val`: V, lookup: MutableMap<K, MutableSet<V>>) {
-            val values = lookup.getOrDefault(key, HashSet())!!
+            val values = lookup.getOrDefault(key, HashSet())
             if (values.isEmpty()) lookup[key] = values
             values.add(`val`)
         }

--- a/src/main/kotlin/se/kth/spork/base3dm/Content.kt
+++ b/src/main/kotlin/se/kth/spork/base3dm/Content.kt
@@ -9,10 +9,10 @@ import java.util.Objects
  * @param value The value of the this content.
  */
 data class Content<T : ListNode, V>(val context: Pcs<T>, val value: V, val revision: Revision) {
-    override fun equals(o: Any?): Boolean {
-        if (this === o) return true
-        if (o == null || javaClass != o.javaClass) return false
-        val content = o as Content<*, *>
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || javaClass != other.javaClass) return false
+        val content = other as Content<*, *>
         return context == content.context &&
             value == content.value
     }

--- a/src/main/kotlin/se/kth/spork/spoon/Spoon3dmMerge.kt
+++ b/src/main/kotlin/se/kth/spork/spoon/Spoon3dmMerge.kt
@@ -159,7 +159,7 @@ object Spoon3dmMerge {
         )
         // we can be certain that the merge tree has the same root type as the three constituents,
         // so this cast is safe
-        val mergeTree = merge.first as T
+        @Suppress("UNCHECKED_CAST") val mergeTree = merge.first as T
         val numConflicts = merge.second
         val metadataElementConflicts = mergeMetadataElements(mergeTree, base, left, right)
         LOGGER.info { "Checking for duplicated members" }
@@ -272,7 +272,7 @@ object Spoon3dmMerge {
             // badness in the Spoon API: addTypeMember returns a generic type that depends only on the
             // static type of the returned expression. So we must store the returned expression and declare
             // the type, or Kotlin gets grumpy.
-            val dontcare: CtType<*> = type.addTypeMember(mergedMember)
+            @Suppress("UNUSED_VARIABLE") val dontcare: CtType<*> = type.addTypeMember(mergedMember)
         }
 
         return numConflicts
@@ -309,6 +309,7 @@ object Spoon3dmMerge {
      * @param right The right revision.
      * @return A merged import list, sorted in lexicographical order.
      */
+    @Suppress("UNCHECKED_CAST")
     private fun mergeImportStatements(
         base: CtElement,
         left: CtElement,

--- a/src/main/kotlin/se/kth/spork/spoon/conflict/ModifierHandler.kt
+++ b/src/main/kotlin/se/kth/spork/spoon/conflict/ModifierHandler.kt
@@ -17,6 +17,7 @@ class ModifierHandler : ContentConflictHandler {
     override val role: CtRole
         get() = CtRole.MODIFIER
 
+    @Suppress("UNCHECKED_CAST")
     override fun handleConflict(
         baseVal: Any?,
         leftVal: Any,

--- a/src/main/kotlin/se/kth/spork/spoon/matching/MappingRemover.kt
+++ b/src/main/kotlin/se/kth/spork/spoon/matching/MappingRemover.kt
@@ -51,7 +51,7 @@ class MappingRemover(private val mapping: SpoonMapping) : CtScanner() {
             val baseRightMappingRemover = MappingRemover(baseRight)
             val leftRightMappingRemover = MappingRemover(leftRight)
             for (node in nodes) {
-                when (node.revision!!) {
+                when (node.revision) {
                     Revision.BASE -> {
                         leftRightMappingRemover.removeRelatedMappings(baseLeft.getDst(node)!!)
                         baseLeftMappingRemover.removeRelatedMappings(node)

--- a/src/main/kotlin/se/kth/spork/spoon/matching/SpoonMapping.kt
+++ b/src/main/kotlin/se/kth/spork/spoon/matching/SpoonMapping.kt
@@ -48,15 +48,15 @@ class SpoonMapping private constructor() {
      * @param matches Pairs of matched nodes, as computed by GumTree/gumtree-spoon-ast-diff.
      */
     private fun inferAdditionalMappings(matches: List<Pair<CtElement, CtElement>>) {
-        var matches = matches
-        while (!matches.isEmpty()) {
+        var mutableMatches = matches
+        while (mutableMatches.isNotEmpty()) {
             val newMatches: MutableList<Pair<CtElement, CtElement>> = ArrayList()
-            for (match in matches) {
+            for (match in mutableMatches) {
                 val src = match.first
                 val dst = match.second
                 newMatches.addAll(inferAdditionalMappings(src, dst))
             }
-            matches = newMatches
+            mutableMatches = newMatches
         }
     }
 

--- a/src/main/kotlin/se/kth/spork/spoon/wrappers/NodeFactory.kt
+++ b/src/main/kotlin/se/kth/spork/spoon/wrappers/NodeFactory.kt
@@ -141,7 +141,7 @@ object NodeFactory {
         val cls: Class<out CtElement> = elem.javaClass
         for (explodedType in EXPLODED_TYPES) {
             if (explodedType.isAssignableFrom(cls)) {
-                return EXPLODED_TYPE_ROLES!![explodedType]
+                return EXPLODED_TYPE_ROLES[explodedType]
             }
         }
         return emptyList()
@@ -212,10 +212,10 @@ object NodeFactory {
             return longRep
         }
 
-        override fun equals(o: Any?): Boolean {
-            if (this === o) return true
-            if (o == null || javaClass != o.javaClass) return false
-            val wrapper = o as Node
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || javaClass != other.javaClass) return false
+            val wrapper = other as Node
             return key == wrapper.key
         }
 
@@ -291,10 +291,10 @@ object NodeFactory {
 
         override val isStartOfList: Boolean = side == Side.START
 
-        override fun equals(o: Any?): Boolean {
-            if (this === o) return true
-            if (o == null || javaClass != o.javaClass) return false
-            val listEdge = o as ListEdge
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || javaClass != other.javaClass) return false
+            val listEdge = other as ListEdge
             return parent == listEdge.parent &&
                 side == listEdge.side
         }
@@ -330,10 +330,10 @@ object NodeFactory {
 
         override val isVirtual: Boolean = true
 
-        override fun equals(o: Any?): Boolean {
-            if (this === o) return true
-            if (o == null || javaClass != o.javaClass) return false
-            val roleNode = o as RoleNode
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || javaClass != other.javaClass) return false
+            val roleNode = other as RoleNode
             return parent == roleNode.parent &&
                 role == roleNode.role
         }

--- a/src/main/kotlin/se/kth/spork/spoon/wrappers/RoledValue.kt
+++ b/src/main/kotlin/se/kth/spork/spoon/wrappers/RoledValue.kt
@@ -19,10 +19,10 @@ class RoledValue(val role: CtRole, val value: Any?) {
         return metadata[key]
     }
 
-    override fun equals(o: Any?): Boolean {
-        if (this === o) return true
-        if (o == null || javaClass != o.javaClass) return false
-        val that = o as RoledValue
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || javaClass != other.javaClass) return false
+        val that = other as RoledValue
         return role == that.role &&
             value == that.value
     }


### PR DESCRIPTION
This PR adds an option to treat Kotlin compiler warnings as errors, and fixes all outstanding warnings.