### PR TITLE
[misc] Allow Codecov to fail uploading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   file-merge-benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Codecov only allows so many uploads for the same commit, so we want to allow failures after that limit is reached.